### PR TITLE
Move default styles into a separate file for easier overrides

### DIFF
--- a/src/agenda/AgendaEventRenderer.js
+++ b/src/agenda/AgendaEventRenderer.js
@@ -325,10 +325,12 @@ function AgendaEventRenderer() {
 	function draggableDayEvent(event, eventElement, isStart) {
 		if (!opt('disableDragging') && eventElement.draggable) {
 			var origWidth;
+			var origPosition;
 			var allDay=true;
 			var dayDelta;
 			var dis = opt('isRTL') ? -1 : 1;
 			var hoverListener = getHoverListener();
+			var colCnt = getColCnt();
 			var colWidth = getColWidth();
 			var slotHeight = getSlotHeight();
 			var minMinute = getMinMinute();
@@ -340,6 +342,7 @@ function AgendaEventRenderer() {
 					trigger('eventDragStart', eventElement, event, ev, ui);
 					hideEvents(event, eventElement);
 					origWidth = eventElement.width();
+					origPosition = eventElement.position();
 					hoverListener.start(function(cell, origCell, rowDelta, colDelta) {
 						eventElement.draggable('option', 'revert', !cell || !rowDelta && !colDelta);
 						clearOverlays();
@@ -369,6 +372,10 @@ function AgendaEventRenderer() {
 							}
 						}
 					}, ev, 'drag');
+				},
+				drag: function(ev, ui) {
+					var position = Math.min(Math.max(colWidth, ui.position.left), colWidth * colCnt);
+					dayDelta = Math.round((position - origPosition.left) / colWidth);
 				},
 				stop: function(ev, ui) {
 					var cell = hoverListener.stop();
@@ -469,6 +476,8 @@ function AgendaEventRenderer() {
 						}
 						prevMinuteDelta = minuteDelta;
 					}
+					var position = Math.min(Math.max(colWidth, ui.position.left), colWidth * colCnt);
+					dayDelta = Math.round((position - origPosition.left) / colWidth);
 				},
 				stop: function(ev, ui) {
 					var cell = hoverListener.stop();


### PR DESCRIPTION
I'm helping work on the [Drupal implementation](http://drupal.org/project/fullcalendar) of your awesome plugin. So far we've only come across one problem, which is that overriding the default event style is really cumbersome.

I moved the default styles into a default.css, which will allow Drupal to optionally load or ignore those styles. This would be a huge help to us.
