### PR TITLE
viewRender/beforeViewRender trigger

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -186,6 +186,7 @@ function Calendar(element, options, eventSources) {
 	
 	
 	function renderView(inc) {
+		trigger('beforeRender', this);
 		if (elementVisible()) {
 			ignoreWindowResize++; // because renderEvents might temporarily change the height before setSize is reached
 


### PR DESCRIPTION
Hi, in a project I'm currently working on, we need to know when the calendar is going to be rendered. To do this, I needed to add this trigger. Would it be possible to have this merged upstream?

In case you're wondering, I need this for the following:
http://yokohama.savanne.be/tmp/.github/redlines.png

It adds a new background table to the calendar, which shows lines that indicate whether or not the slot is free / busy.

These lines need to be cleared upon switching to a new week, which is why I need the trigger.
