### PR TITLE
Regex to support all ISO8601 timezone offset formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 build/fullcalendar
 build/fullcalendar-*
 dist
+.project
+.settings
+.classpath
+target
+hs_err*
+.tmp_*

--- a/src/date_util.js
+++ b/src/date_util.js
@@ -162,7 +162,11 @@ function parseDate(s, ignoreTimezone) { // ignoreTimezone defaults to true
 function parseISO8601(s, ignoreTimezone) { // ignoreTimezone defaults to false
 	// derived from http://delete.me.uk/2005/03/iso8601.html
 	// TODO: for a know glitch/feature, read tests/issue_206_parseDate_dst.html
-	var m = s.match(/^([0-9]{4})(-([0-9]{2})(-([0-9]{2})([T ]([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?(Z|(([-+])([0-9]{2}):([0-9]{2})))?)?)?)?$/);
+
+	// TNM 2011-02-01: Updated regex to support +0000 or +00 timezones in addition to +00:00
+	// See: http://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC
+	var m = s.match(/^([0-9]{4})(-([0-9]{2})(-([0-9]{2})([T ]([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?(Z|(([-+])([0-9]{2})((:?)([0-9]{2}))?))?)?)?)?$/);
+
 	if (!m) {
 		return null;
 	}
@@ -203,7 +207,7 @@ function parseISO8601(s, ignoreTimezone) { // ignoreTimezone defaults to false
 			m[10] || 0,
 			m[12] ? Number("0." + m[12]) * 1000 : 0
 		);
-		var offset = Number(m[16]) * 60 + Number(m[17]);
+		var offset = Number(m[16]) * 60 + (m[19] ? Number(m[19]) : 0);
 		offset *= m[15] == '-' ? 1 : -1;
 		date = new Date(+date + (offset * 60 * 1000));
 	}


### PR DESCRIPTION
Adam,

I've updated your parseISO8601 function to support all of the following timezone offset formats:

±[hh]:[mm]
±[hh][mm]
±[hh]

These formats are specifically mentioned in the Wikipedia article:
http://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC

My Java server using Jackson for JSON was producing timezone offsets with the format +0000, which FullCalendar wasn't supporting. This simple change fixes it.

This is your regex:
var m = s.match(/^([0-9]{4})(-([0-9]{2})(-([0-9]{2})([T ]([0-9]{2}):([0-9]{2})(:([0-9]{2})(.([0-9]+))?)?(Z|(([-+])([0-9]{2}):([0-9]{2})))?)?)?)?$/);

Here is the new regex:
var m = s.match(/^([0-9]{4})(-([0-9]{2})(-([0-9]{2})([T ]([0-9]{2}):([0-9]{2})(:([0-9]{2})(.([0-9]+))?)?(Z|(([-+])([0-9]{2})((:?)([0-9]{2}))?))?)?)?)?$/);

As you will see, it makes the timezone : divider optional as well as the :mm optional.

I also updated index references to m[x] so they were correct and added a test to make sure we didn't end up with a NaN offset:

```
    var offset = Number(m[16]) * 60 + (m[19] ? Number(m[19]) : 0);
```

I hope you will pull this into your master.
