### PR TITLE
added readyState trigger to renderEvents

### DIFF
--- a/src/agenda/AgendaEventRenderer.js
+++ b/src/agenda/AgendaEventRenderer.js
@@ -71,6 +71,7 @@ function AgendaEventRenderer() {
 			setHeight(); // no params means set to viewHeight
 		}
 		renderSlotSegs(compileSlotSegs(slotEvents), modifiedEventId);
+		trigger('readyState');
 	}
 	
 	

--- a/src/basic/BasicEventRenderer.js
+++ b/src/basic/BasicEventRenderer.js
@@ -41,6 +41,7 @@ function BasicEventRenderer() {
 	function renderEvents(events, modifiedEventId) {
 		reportEvents(events);
 		renderDaySegs(compileSegs(events), modifiedEventId);
+		trigger('readyState');
 	}
 	
 	


### PR DESCRIPTION
Added a readyState trigger at the end of each renderEvents function.  This is necessary for code which needs to act after a set of events is rendered.  One use-case for this is when events are pulled via ajax within Drupal. Drupal.attachBehaviors needs to be run after new content is added to the DOM but is a fairly heavy function and so cannot reasonably be run against each event individually as it is rendered.  This is a possible solution to issue #753.
