### PR TITLE
Small change with links

### DIFF
--- a/src/common/DayEventRenderer.js
+++ b/src/common/DayEventRenderer.js
@@ -169,15 +169,11 @@ function DayEventRenderer() {
 			}
 			url = event.url;
 			skinCss = getSkinCss(event, opt);
-			if (url) {
-				html += "<a href='" + htmlEscape(url) + "'";
-			}else{
-				html += "<div";
-			}
 			html +=
-				" class='" + classes.join(' ') + "'" +
+				"<div class='" + classes.join(' ') + "'" +
 				" style='position:absolute;z-index:8;left:"+left+"px;" + skinCss + "'" +
 				">" +
+				((url) ? "<a href='" + htmlEscape(url) + "'>" : '')+
 				"<div" +
 				" class='fc-event-inner fc-event-skin'" +
 				(skinCss ? " style='" + skinCss + "'" : '') +
@@ -197,8 +193,7 @@ function DayEventRenderer() {
 					"&nbsp;&nbsp;&nbsp;" + // makes hit area a lot better for IE6/7
 					"</div>";
 			}
-			html +=
-				"</" + (url ? "a" : "div" ) + ">";
+			html +=(url ? "</a>" : "" )+"</div>";
 			seg.left = left;
 			seg.outerWidth = right - left;
 			seg.startCol = leftCol;


### PR DESCRIPTION
I used to attach an overlay to the month-view event div with a menu to
delete/edit the event. This was not possible in 1.5 any longer, cause it
used the link OR the div. This small fix should work for all and let me
add the menu again.  Demo:
http://kompsoft.de/test/eqdkp/ajax/fullcalendar/demos/
