### PR TITLE
option to send ISO date for startParam/endParam

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -130,10 +130,10 @@ function EventManager(options, _sources) {
 				var startParam = firstDefined(source.startParam, options.startParam);
 				var endParam = firstDefined(source.endParam, options.endParam);
 				if (startParam) {
-					data[startParam] = Math.round(+rangeStart / 1000);
+					data[startParam] = (options.startEndDateOnly) ? (rangeStart.getYear()+'-'+(rangeStart.getMonth()+1)+'-'+rangeStart.getDate()) : Math.round(+rangeStart / 1000);
 				}
 				if (endParam) {
-					data[endParam] = Math.round(+rangeEnd / 1000);
+					data[endParam] = (options.startEndDateOnly) ? (rangeEnd.getYear()+'-'+(rangeEnd.getMonth()+1)+'-'+rangeEnd.getDate()) : Math.round(+rangeEnd / 1000);
 				}
 				pushLoading();
 				$.ajax($.extend({}, ajaxDefaults, source, {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -19,10 +19,12 @@ var defaults = {
 	allDayDefault: true,
 	ignoreTimezone: true,
 	
+
 	// event ajax
 	lazyFetching: true,
 	startParam: 'start',
 	endParam: 'end',
+        startEndDateOnly: false,
 	
 	// time formats
 	titleFormat: {


### PR DESCRIPTION
Since the next/prev is instructing the server to provide new data based on days, and not times, it makes sense to have the ability to only submit Date information - this avoids the problems generated from not knowing the users timezones. 

To extract date information from a unixtime without knowing the timezone it was generated in is problematic.

I'm not entirely sure what the purpose or utility of having the Time information for this is, but in the nature of not breaking the library i've made sure unixtime is the default

this is an alternative to: https://github.com/arshaw/fullcalendar/pull/35

solves the same problem, but without needing to then parse the time in UTC to extract the date on the server side 
