### PR TITLE
Timed events end should be set after drag

### DIFF
--- a/src/common/View.js
+++ b/src/common/View.js
@@ -235,6 +235,8 @@ function View(element, calendar, viewName) {
 			addMinutes(addDays(e.start, dayDelta, true), minuteDelta);
 			if (e.end) {
 				e.end = addMinutes(addDays(e.end, dayDelta, true), minuteDelta);
+			} else {
+				e.end = defaultEventEnd(e);
 			}
 			normalizeEvent(e, options);
 		}


### PR DESCRIPTION
I created ussue 1206: Moving from "allDay" event to Day timeline should set end time/date. Here is a fix for it.
