### PR TITLE
Apply ui-button class to buttons when needed

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -71,7 +71,7 @@ function Header(calendar, options) {
 							var icon = options.theme ? smartProperty(options.buttonIcons, buttonName) : null; // why are we using smartProperty here?
 							var text = smartProperty(options.buttonText, buttonName); // why are we using smartProperty here?
 							var button = $(
-								"<span class='fc-button fc-button-" + buttonName + " " + tm + "-state-default'>" +
+								"<span class='fc-button "+(tm == 'ui' ? 'ui-button' : '')+" fc-button-" + buttonName + " " + tm + "-state-default'>" +
 									"<span class='fc-button-inner'>" +
 										"<span class='fc-button-content'>" +
 											(icon ?


### PR DESCRIPTION
Header buttons don't get the required class `ui-button` when `theme` is enabled.

For instance, Aristo jQuery UI theme shows a light glow around buttons when mouse is over them, but Fullcalendar buttons don't show it without this class applied.
