### PR TITLE
Change bodyVisible to check the body element exists first

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -125,7 +125,8 @@ function Calendar(element, options, eventSources) {
 	
 	
 	function bodyVisible() {
-		return $('body')[0].offsetWidth !== 0;
+        var body = $('body');
+		return body.length > 0 && body [0].offsetWidth !== 0;
 	}
 	
 	


### PR DESCRIPTION
Change bodyVisible to check the body element actually exists before accessing offsetWidth.

This prevents errors if FC is used before the DOM has loaded (ie. on an invisible element).
