### PR TITLE
put dateFormatters to options, so we can overwrite/extend them if needed

### DIFF
--- a/src/date_util.js
+++ b/src/date_util.js
@@ -304,7 +304,7 @@ function formatDates(date1, date2, format, options) {
 		}
 		else {
 			for (i2=len; i2>i; i2--) {
-				if (formatter = dateFormatters[format.substring(i, i2)]) {
+				if (formatter = options.dateFormatters[format.substring(i, i2)]) {
 					if (date) {
 						res += formatter(date, options);
 					}
@@ -320,40 +320,6 @@ function formatDates(date1, date2, format, options) {
 		}
 	}
 	return res;
-};
-
-
-var dateFormatters = {
-	s	: function(d)	{ return d.getSeconds() },
-	ss	: function(d)	{ return zeroPad(d.getSeconds()) },
-	m	: function(d)	{ return d.getMinutes() },
-	mm	: function(d)	{ return zeroPad(d.getMinutes()) },
-	h	: function(d)	{ return d.getHours() % 12 || 12 },
-	hh	: function(d)	{ return zeroPad(d.getHours() % 12 || 12) },
-	H	: function(d)	{ return d.getHours() },
-	HH	: function(d)	{ return zeroPad(d.getHours()) },
-	d	: function(d)	{ return d.getDate() },
-	dd	: function(d)	{ return zeroPad(d.getDate()) },
-	ddd	: function(d,o)	{ return o.dayNamesShort[d.getDay()] },
-	dddd: function(d,o)	{ return o.dayNames[d.getDay()] },
-	M	: function(d)	{ return d.getMonth() + 1 },
-	MM	: function(d)	{ return zeroPad(d.getMonth() + 1) },
-	MMM	: function(d,o)	{ return o.monthNamesShort[d.getMonth()] },
-	MMMM: function(d,o)	{ return o.monthNames[d.getMonth()] },
-	yy	: function(d)	{ return (d.getFullYear()+'').substring(2) },
-	yyyy: function(d)	{ return d.getFullYear() },
-	t	: function(d)	{ return d.getHours() < 12 ? 'a' : 'p' },
-	tt	: function(d)	{ return d.getHours() < 12 ? 'am' : 'pm' },
-	T	: function(d)	{ return d.getHours() < 12 ? 'A' : 'P' },
-	TT	: function(d)	{ return d.getHours() < 12 ? 'AM' : 'PM' },
-	u	: function(d)	{ return formatDate(d, "yyyy-MM-dd'T'HH:mm:ss'Z'") },
-	S	: function(d)	{
-		var date = d.getDate();
-		if (date > 10 && date < 20) {
-			return 'th';
-		}
-		return ['st', 'nd', 'rd'][date%10-1] || 'th';
-	}
 };
 
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -67,7 +67,40 @@ var defaults = {
 	//selectable: false,
 	unselectAuto: true,
 	
-	dropAccept: '*'
+	dropAccept: '*',
+	
+	dateFormatters: {
+		s	: function(d)	{ return d.getSeconds() },
+		ss	: function(d)	{ return zeroPad(d.getSeconds()) },
+		m	: function(d)	{ return d.getMinutes() },
+		mm	: function(d)	{ return zeroPad(d.getMinutes()) },
+		h	: function(d)	{ return d.getHours() % 12 || 12 },
+		hh	: function(d)	{ return zeroPad(d.getHours() % 12 || 12) },
+		H	: function(d)	{ return d.getHours() },
+		HH	: function(d)	{ return zeroPad(d.getHours()) },
+		d	: function(d)	{ return d.getDate() },
+		dd	: function(d)	{ return zeroPad(d.getDate()) },
+		ddd	: function(d,o)	{ return o.dayNamesShort[d.getDay()] },
+		dddd: function(d,o)	{ return o.dayNames[d.getDay()] },
+		M	: function(d)	{ return d.getMonth() + 1 },
+		MM	: function(d)	{ return zeroPad(d.getMonth() + 1) },
+		MMM	: function(d,o)	{ return o.monthNamesShort[d.getMonth()] },
+		MMMM: function(d,o)	{ return o.monthNames[d.getMonth()] },
+		yy	: function(d)	{ return (d.getFullYear()+'').substring(2) },
+		yyyy: function(d)	{ return d.getFullYear() },
+		t	: function(d)	{ return d.getHours() < 12 ? 'a' : 'p' },
+		tt	: function(d)	{ return d.getHours() < 12 ? 'am' : 'pm' },
+		T	: function(d)	{ return d.getHours() < 12 ? 'A' : 'P' },
+		TT	: function(d)	{ return d.getHours() < 12 ? 'AM' : 'PM' },
+		u	: function(d)	{ return formatDate(d, "yyyy-MM-dd'T'HH:mm:ss'Z'") },
+		S	: function(d)	{
+			var date = d.getDate();
+			if (date > 10 && date < 20) {
+				return 'th';
+			}
+			return ['st', 'nd', 'rd'][date%10-1] || 'th';
+		}
+	}
 	
 };
 


### PR DESCRIPTION
i wanted an agenda week with just two rows (morning and afternoon)

e.g.

```
$myContainer.fullCalendar({
    ....
    axisFormat: 'tl', //rows - time
    slotMinutes: 360,
    defaultView: 'agendaWeek',
    minTime: 6,
    maxTime: 18,
    dateFormatters: {
        tl  : function(d)   { return d.getHours() < 12 ? 'vormittag' : 'nachmittag' },
    },
    ...
});
```
