### PR TITLE
Add cell date as data attribute and provide a custom selector for it

### DIFF
--- a/src/basic/BasicView.js
+++ b/src/basic/BasicView.js
@@ -211,6 +211,8 @@ function BasicView(element, calendar, viewName) {
 			}else{
 				cell.removeClass(tm + '-state-highlight fc-today');
 			}
+			cell.data("cell-date", date);
+			cell.addClass("fc-date");
 			cell.find('div.fc-day-number').text(date.getDate());
 			if (dowDirty) {
 				setDayID(cell, date);

--- a/src/main.js
+++ b/src/main.js
@@ -57,6 +57,27 @@ $.fn.fullCalendar = function(options) {
 	
 };
 
+$.extend($.expr[":"], {
+  "cell-date": function(element, i, match, array) {
+    var exprDate = "" + match[3];
+    var cellDate = $(element).data("cell-date");
+    var day = cellDate.getDate();
+    var month = cellDate.getMonth() + 1;
+    var year = cellDate.getFullYear();
+    // Match mm-dd-yyy
+    var matchResult = /^(\d{1,2})-(\d{1,2})-(\d{4})$/.exec(exprDate) || /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(exprDate);
+    if (matchResult) {
+      return month == parseInt(matchResult[1], 10) && day == parseInt(matchResult[2], 10) && year == matchResult[3];
+    }
+    // Match yyyy-mm-dd
+    matchResult = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(exprDate) || /^(\d{4})\/(\d{1,2})\/(\d{1,2})$/.exec(exprDate);
+    if (matchResult) {
+      return month == parseInt(matchResult[2], 10) && day == parseInt(matchResult[3], 10) && year == matchResult[1];
+    }
+    // Match timestamps
+    return +cellDate == exprDate;
+  }
+});
 
 // function for adding/overriding defaults
 function setDefaults(d) {


### PR DESCRIPTION
In one of our projects that's using fullcalendar, we needed a way to style certain cells differently. For example, we have the user select a date first, then render the calendar, we want to style the cell that represents the date differently, we also needed to style cells based on their content, so we needed a way to identify the cells based on the data we're putting into it.

The minimal plugin modification we came up with was to store the date attribute in the cells, then use a custom jquery selector to grab whatever cells we want, and then style them as we wish in callbacks.

This could potentially be helpful to others.

Thanks for all the great work on fullcalendar
