### PR TITLE
Fixed issue with events overlapping on month view when returning false (for some events) in eventRender.

### DIFF
--- a/src/common/DayEventRenderer.js
+++ b/src/common/DayEventRenderer.js
@@ -74,7 +74,7 @@ function DayEventRenderer() {
 				// loop through segs in a row
 				top = arrayMax(colHeights.slice(seg.startCol, seg.endCol));
 				seg.top = top;
-				top += seg.outerHeight;
+				if (typeof seg.outerHeight != "undefined") top += seg.outerHeight;
 				for (k=seg.startCol; k<seg.endCol; k++) {
 					colHeights[k] = top;
 				}


### PR DESCRIPTION
Fixed this bug:  http://code.google.com/p/fullcalendar/issues/detail?id=762  
