### PR TITLE
Add disabling of drag/resize for individual events

### DIFF
--- a/src/common/View.js
+++ b/src/common/View.js
@@ -66,12 +66,14 @@ function View(element, calendar, viewName) {
 	
 	
 	function isEventDraggable(event) {
-		return isEventEditable(event) && !opt('disableDragging');
+		return isEventEditable(event) && !opt('disableDragging') &&
+				!event.disableDragging;
 	}
 	
 	
 	function isEventResizable(event) { // but also need to make sure the seg.isEnd == true
-		return isEventEditable(event) && !opt('disableResizing');
+		return isEventEditable(event) && !opt('disableResizing') &&
+			!event.disableResizing;
 	}
 	
 	


### PR DESCRIPTION
This is my proposed solution to [issue 174](http://code.google.com/p/fullcalendar/issues/detail?id=174) in the bug tracker.

This implementation allows `disableDragging` and `disableResizing` properties to be specified for specific events.  These properties can already be specified at the calendar level.  This is similar to the `editable` property that can already be specified at both the calendar and event levels.

This is a completely backwards compatible feature.
