### PR TITLE
Add option to not automatically hook window.resize

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -91,7 +91,9 @@ function Calendar(element, options, eventSources) {
 			element.prepend(headerElement);
 		}
 		changeView(options.defaultView);
-		$(window).resize(windowResize);
+		if (options.hookWindowResize) {
+			$(window).resize(windowResize);
+		}
 		// needed for IE in a 0x0 iframe, b/c when it is resized, never triggers a windowResize
 		if (!bodyVisible()) {
 			lateRender();

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -67,7 +67,9 @@ var defaults = {
 	//selectable: false,
 	unselectAuto: true,
 	
-	dropAccept: '*'
+	dropAccept: '*',
+	
+	hookWindowResize: true
 	
 };
 


### PR DESCRIPTION
It can be useful to remove the responsibility to resizing from the fullcalendar control and instead have the developer manually trigger the required 'render' whenever /she/ deems that a resize happened. Consider cases where resize should only be triggered on a debounce because of complicated sizing code, or cases where the new size of the calendar component is dependent on the _manually computed_ value of parent container.

In these cases, fullcalendar is inefficient because in effect the resize event is being triggered way too often.

This pull request simply delegates the responsibility to resize to the user of the fullcalendar control.
