### PR TITLE
fixes bug where dragging an event in agenda view does not always result in correct event-positioning

### DIFF
--- a/src/agenda/AgendaEventRenderer.js
+++ b/src/agenda/AgendaEventRenderer.js
@@ -501,6 +501,7 @@ function AgendaEventRenderer() {
 				}, ev, 'drag');
 			},
 			drag: function(ev, ui) {
+				ui.position.left = origPosition.left + (dayDelta * dis) * colWidth;
 				minuteDelta = Math.round((ui.position.top - origPosition.top) / slotHeight) * opt('slotMinutes');
 				if (minuteDelta != prevMinuteDelta) {
 					if (!allDay) {


### PR DESCRIPTION
- when dragging an event to the left or to the right, the event snaps to
  a new position but calculation (dayDelta) is performed using the
  hoverlistener, which reports the current delta for the mouse-position
  that may still be over another cell.
  How to reproduce: position pointer over right edge of an event and start
  dragging it to the left until it snaps to its new position, then release
  the mouse button. the event will be reset to its original position
