### PR TITLE
added trigger 'headerCreated'

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -89,6 +89,7 @@ function Calendar(element, options, eventSources) {
 		headerElement = header.render();
 		if (headerElement) {
 			element.prepend(headerElement);
+			trigger("headerCreated", headerElement, headerElement);
 		}
 		changeView(options.defaultView);
 		$(window).resize(windowResize);


### PR DESCRIPTION
may be used to append additional content to the calendar header before the remaining size-calculations
are performed.
