### PR TITLE
Use the elements z-index as base for z-index calculations when resizing and dragging

### DIFF
--- a/src/agenda/AgendaEventRenderer.js
+++ b/src/agenda/AgendaEventRenderer.js
@@ -456,6 +456,7 @@ function AgendaEventRenderer() {
 	
 	function draggableSlotEvent(event, eventElement, timeElement) {
 		var origPosition;
+		var origZIndex = eventElement.zIndex();
 		var allDay=false;
 		var dayDelta;
 		var minuteDelta;
@@ -466,7 +467,7 @@ function AgendaEventRenderer() {
 		var colWidth = getColWidth();
 		var slotHeight = getSlotHeight();
 		eventElement.draggable({
-			zIndex: 9,
+			zIndex: origZIndex + 1,
 			scroll: false,
 			grid: [colWidth, slotHeight],
 			axis: colCnt==1 ? 'y' : false,

--- a/src/basic/BasicEventRenderer.js
+++ b/src/basic/BasicEventRenderer.js
@@ -98,9 +98,9 @@ function BasicEventRenderer() {
 	function draggableDayEvent(event, eventElement) {
 		var hoverListener = getHoverListener();
 		var dayDelta;
-		var prevZIndex = eventElement.zIndex();
+		var origZIndex = eventElement.zIndex();
 		eventElement.draggable({
-			zIndex: prevZIndex + 1,
+			zIndex: origZIndex + 1,
 			delay: 50,
 			opacity: opt('dragOpacity'),
 			revertDuration: opt('dragRevertDuration'),


### PR DESCRIPTION
When resizing and dragging, a fixed z-index was used and set (in case of resizing) on the event-element. If the z-index was altered by the developer, it was reset after resizing.
With this patch, the original z-index of the event-element is taken into account.
