### PR TITLE
agenda view event overlapping fix

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -27,7 +27,7 @@ function segCmp(a, b) {
 
 
 function segsCollide(seg1, seg2) {
-	return seg1.end > seg2.start && seg1.start < seg2.end;
+	return seg1.end >= seg2.start && seg1.start <= seg2.end;
 }
 
 


### PR DESCRIPTION
Screenshots in my own project - 
Before: http://cl.ly/image/2V3q2Z0R0i05
After: http://cl.ly/image/3N2Y2K1A2q3m

Issue 1363 on Google Project Hosting:

"When many events exist in a close time period, one or more events may become hidden by overlapping events that start before the overlapped event. 

This is pretty serious issue since it prevents people from actually being able to view all the events on their calendar.

Attachment storage is exceeded so here is a screenshot on dropbox. http://dl.dropbox.com/u/38691/overlapbug.png

Any thoughts on work arounds or quick fixes? Thanks."
