### PR TITLE
Support for ASP.net MVC Json DateTime

### DIFF
--- a/src/date_util.js
+++ b/src/date_util.js
@@ -145,6 +145,9 @@ function parseDate(s, ignoreTimezone) { // ignoreTimezone defaults to true
 	if (typeof s == 'number') { // a UNIX timestamp
 		return new Date(s * 1000);
 	}
+  if (s.match(/^\/Date\([0-9]+\)\/$/)) { // a .NET Json serializaed date
+		return new Date(s.match(/[0-9]+/));
+	}
 	if (typeof s == 'string') {
 		if (s.match(/^\d+(\.\d+)?$/)) { // a UNIX timestamp
 			return new Date(parseFloat(s) * 1000);


### PR DESCRIPTION
I just added a small hack to parseDate, so it can now support JSON serialized DateTime, created by JsonResult in ASP .net MVC.
