### PR TITLE
Add ability to define custom header element via callback

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -56,6 +56,16 @@ function Header(calendar, options) {
 							prevButton.addClass(tm + '-corner-right');
 						}
 						prevButton = null;
+
+					//Allow a callback to define a custom header element - such as a filter
+					}else if( $.isFunction(options.filters[buttonName]) ){
+
+						//Use callback to define custom header element - pass options as argument.
+						var html =options.filters[buttonName](options);
+
+						var element =  $("<span class='fc-header-"+buttonName+"'></span>").append(html);
+ 						e.append(element);
+
 					}else{
 						var buttonClick;
 						if (calendar[buttonName]) {


### PR DESCRIPTION
Hi Adam,

Thank you for a fantastic jQuery plug-in! I've been using it as part of an event management plug-in for WordPress. I needed a couple of drop-down filters added to the header of the calendar, so I've added an option: 'filters' which takes an object, with a filter ID as property, and a callback function as the value. 

The filters are added along with the buttons (if the button name matches a filter), and the callback defines the mark-up. So more generally - anything can be added to the header of the calendar (so 'filters' might be a misleading name).

Would be great to see (something like) this added!

**Example usage:**
(I've omitted the defining of the category terms)

```
function category_dropdown(options){

     //options.categories stores category term objects
     var terms = options.categories;

     //Generate HTML
     var html="<select class='eo-cal-filter' id='eo-event-cat'>";
     html+="<option value=''>"+options.buttonText.cat+"</option>";
     for (var i=0;i<2; i++) {
          html+= "<option value='"+terms[i].slug+"'>"+terms[i].name+"</option>";
     }
     html+="</select>";

     return html;
}

  $('#calendar').fullCalendar({
        filters:{
              category:  category_dropdown,
        },
        header: {
              left: 'category'
        },
  });
```
