### PR TITLE
Added support for cellDisplay callback option

### DIFF
--- a/src/agenda/AgendaView.js
+++ b/src/agenda/AgendaView.js
@@ -321,6 +321,9 @@ function AgendaView(element, calendar, viewName) {
 				bodyCell.removeClass(tm + '-state-highlight fc-today');
 			}
 			setDayID(headCell.add(bodyCell), date);
+			if(typeof opt('cellDisplay') === 'function') {
+				opt('cellDisplay').call(bodyCell, bodyCell, date);
+			}
 		}
 	}
 	

--- a/src/basic/BasicView.js
+++ b/src/basic/BasicView.js
@@ -215,6 +215,9 @@ function BasicView(element, calendar, viewName) {
 			if (dowDirty) {
 				setDayID(cell, date);
 			}
+			if(typeof opt('cellDisplay') === 'function') {
+				opt('cellDisplay').call(cell, cell, date);
+			}
 		});
 		
 		bodyRows.each(function(i, _row) {


### PR DESCRIPTION
This changeset adds a 'cellDisplay' callback option to be called after a cell has been rendered. This allows us to add custom styling to certain cells (for example, holidays or special events).

`
$('#calendar).fullCalendar({
    cellDisplay: function(cell, date) {
      $(cell).css({ background: 'pink' });
    }
});`
