### PR TITLE
non allDay multi day event headers

### DIFF
--- a/demos/agenda-views.html
+++ b/demos/agenda-views.html
@@ -25,6 +25,7 @@
 				right: 'month,agendaWeek,agendaDay'
 			},
 			editable: true,
+			//hideMultiDayTimeHeader: true,
 			events: [
 				{
 					title: 'All Day Event',
@@ -69,6 +70,12 @@
 					start: new Date(y, m, 28),
 					end: new Date(y, m, 29),
 					url: 'http://google.com/'
+				},
+				{
+					title: 'Long flight',
+					start: new Date(y, m, d - 1, 10, 30, 0),
+					end: new Date(y, m, d + 1, 7, 0, 0),
+					allDay: false
 				}
 			]
 		});

--- a/src/agenda/AgendaEventRenderer.js
+++ b/src/agenda/AgendaEventRenderer.js
@@ -280,6 +280,8 @@ function AgendaEventRenderer() {
 		var skinCss = getSkinCss(event, opt);
 		var skinCssAttr = (skinCss ? " style='" + skinCss + "'" : '');
 		var classes = ['fc-event', 'fc-event-skin', 'fc-event-vert'];
+		//middle segment or last segment, everything but first segment
+		var hideTimeHeader = opt('hideMultiDayTimeHeader') && ((!seg.isEnd && !seg.isStart) || (seg.isEnd && !seg.isStart));
 		if (isEventDraggable(event)) {
 			classes.push('fc-event-draggable');
 		}
@@ -304,9 +306,11 @@ function AgendaEventRenderer() {
 			">" +
 			"<div class='fc-event-inner fc-event-skin'" + skinCssAttr + ">" +
 			"<div class='fc-event-head fc-event-skin'" + skinCssAttr + ">" +
-			"<div class='fc-event-time'>" +
-			htmlEscape(formatDates(event.start, event.end, opt('timeFormat'))) +
-			"</div>" +
+			( hideTimeHeader ? "" :
+				"<div class='fc-event-time'>" +
+				htmlEscape(formatDates(event.start, event.end, opt('timeFormat'))) +
+				"</div>"
+			) +
 			"</div>" +
 			"<div class='fc-event-content'>" +
 			"<div class='fc-event-title'>" +

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -38,7 +38,8 @@ var defaults = {
 	timeFormat: { // for event elements
 		'': 'h(:mm)t' // default
 	},
-	
+	hideMultiDayTimeHeader: false,
+
 	// locale
 	isRTL: false,
 	firstDay: 0,

--- a/tests/agenda_week_hide_headers.html
+++ b/tests/agenda_week_hide_headers.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+<head>
+<script type='text/javascript' src='../src/_loader.js'></script>
+<!--[[
+<link rel='stylesheet' type='text/css' href='../fullcalendar/fullcalendar.css' />
+<link rel='stylesheet' type='text/css' href='../fullcalendar/fullcalendar.print.css' media='print' />
+<script type='text/javascript' src='../jquery/jquery.js'></script>
+<script type='text/javascript' src='../jquery/jquery-ui.js'></script>
+<script type='text/javascript' src='../fullcalendar/fullcalendar.min.js'></script>
+]]-->
+<script type='text/javascript'>
+	$(document).ready(function() {
+		var date = new Date();
+		var d = date.getDate();
+		var m = date.getMonth();
+		var y = date.getFullYear();
+
+		var to_day = date.getDay();
+		var monday = new Date();
+		monday.setDate(date.getDate() - to_day + (to_day == 0 ? -6:1));
+
+		$('#calendar').fullCalendar({
+			header: {
+				left: 'prev,next today',
+				center: 'title',
+				right: 'month,agendaWeek,agendaDay'
+			},
+			defaultView: 'agendaWeek',
+			editable: true,
+			hideMultiDayTimeHeader: true, //option to hide the time header on events that span multiple days in agenda week view
+			//isRTL: true,
+			events: [
+				{
+					title: 'All Day Event',
+					start: new Date(y, m, d),
+					allDay: true
+				},
+				{
+					title: 'Multi All Day Event',
+					start: new Date(y, m, d+1),
+					end: new Date(y, m, d+3),
+					allDay: true
+				},
+				{
+					title: 'Meeting',
+					start: new Date(y, m, d+2, 10, 30),
+					allDay: false
+				},
+				{
+					title: 'A Long flight',
+					start: new Date(y, m, d - 1, 10, 30, 0),
+					end: new Date(y, m, d + 1, 7, 0, 0),
+					allDay: false
+				},
+				{
+					title: 'Previous Week Long flight',
+					start: new Date(y, m, monday.getDate()-3, 10, 30, 0), //friday
+					end: new Date(y, m, monday.getDate(), 7, 0, 0), //monday
+					allDay: false
+				}
+			]
+		});
+	});
+
+</script>
+<style type='text/css'>
+
+	body {
+		margin-top: 40px;
+		text-align: center;
+		font-size: 14px;
+		font-family: "Lucida Grande",Helvetica,Arial,Verdana,sans-serif;
+		}
+
+	#calendar {
+		width: 900px;
+		margin: 0 auto;
+		}
+
+</style>
+</head>
+<body>
+<div id='calendar'></div>
+</body>
+</html>


### PR DESCRIPTION
I encountered a peculiarity in some of the formatting for events in the agenda view. In particular events that span over multiple days but are not labeled as allDay. 

So for instance an event that start today at 10:30am but ends 2 days from now at 7pm (like a long flight). In the week view the time header that is added to the any of the segments > 1 is the same as the first time segment. Which is a bit confusing to the user because it says the job starts at 10:30am but the segment actually starts at midnight.

You can check out the cases I tested for in this file:
tests/agenda_week_hide_headers.html

Just toggle the hideMultiDayTimeHeader option I added to control this feature.

Another possibility - instead of hiding the header we could show the date as well as the time.

<pre>
    monday              tuesday                  wednesday
                     _____________              _____________
 _____________      | 11/19 10:30 |            | 11/19 10:30 |
| 11/19 10:30 |
</pre>


I am unsure which option you like better. I coded the simpler of the two. 
