### PR TITLE
Adding priority when sorting events

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -22,8 +22,13 @@ function _exclEndDay(end, allDay) {
 
 
 function segCmp(a, b) {
-	return (b.msLength - a.msLength) * 100 + (a.event.start - b.event.start);
+	// Enable priority on events, put a higher number go get higher priority.
+	// If no integer is given, order by time as before.
+    var priorityDiff = ((a.event.priority || 0) < (b.event.priority || 0)) ? 1 : ((b.event.priority || 0) < (a.event.priority || 0)) ? -1 : 0;
+    if(priorityDiff != 0) return priorityDiff;
+    return (b.msLength - a.msLength) * 100 + (a.event.start - b.event.start);
 }
+
 
 
 function segsCollide(seg1, seg2) {


### PR DESCRIPTION
This helps people that have events that should be prioritized. I've changed the code in such a way that if an event got a priority it will try and sort by the highest priority which is an integer. If no priority is found or if it's not set it will sort by time as before. Normal users won't get affected.

documentation & reason: http://stackoverflow.com/questions/15226946/render-event-on-top-fullcalendar.

No test available since it's such a little change.
