### PR TITLE
Error when set a null title on event

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -254,6 +254,7 @@ function smartProperty(obj, name) { // get a camel-cased/namespaced property of 
 
 
 function htmlEscape(s) {
+  if(s === null) { return ''; };
 	return s.replace(/&/g, '&amp;')
 		.replace(/</g, '&lt;')
 		.replace(/>/g, '&gt;')

--- a/tests/options.html
+++ b/tests/options.html
@@ -130,7 +130,7 @@
 					allDay: false
 				},
 				{
-					title: 'Click for Google',
+					title: null,
 					start: new Date(y, m, 28),
 					end: new Date(y, m, 29),
 					url: 'http://google.com/'


### PR DESCRIPTION
When you create an event with a null value you get an error, cause can't found the method replace. So if I get data from Google Calendar with null value on title, the calendar crash.

I modified a test file with null value for an event to test this issue.
