### PR TITLE
Make it configurable whether the first event displayed should be larger than subsequent.

### DIFF
--- a/src/agenda/AgendaEventRenderer.js
+++ b/src/agenda/AgendaEventRenderer.js
@@ -188,7 +188,11 @@ function AgendaEventRenderer() {
 			}else{
 				if (forward) {
 					// moderately wide, aligned left still
-					outerWidth = ((availWidth / (forward + 1)) - (12/2)) * 2; // 12 is the predicted width of resizer =
+					if (opt('firstEventLarger')) {
+						outerWidth = ((availWidth / (forward + 1)) - (12/2)) * 2; // 12 is the predicted width of resizer =
+					}else{
+						outerWidth = availWidth / (forward + 1);
+					}
 				}else{
 					// can be entire width, aligned left
 					outerWidth = availWidth;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -67,8 +67,9 @@ var defaults = {
 	//selectable: false,
 	unselectAuto: true,
 	
-	dropAccept: '*'
+	dropAccept: '*',
 	
+	firstEventLarger: true
 };
 
 // right-to-left defaults


### PR DESCRIPTION
This is the solution from https://code.google.com/p/fullcalendar/issues/detail?id=218#c15, made configurable.

This pull request does not add spacing to events, that is in #86 (which also contains this one). Only one (if any) of these two requests should be pulled.
