### PR TITLE
Make it configurable whether the first event displayed should be larger than subsequent with configurable horizontal spacing

### DIFF
--- a/src/agenda/AgendaEventRenderer.js
+++ b/src/agenda/AgendaEventRenderer.js
@@ -203,7 +203,7 @@ function AgendaEventRenderer() {
 				* dis + (rtl ? availWidth - outerWidth : 0);   // rtl
 			seg.top = top;
 			seg.left = left;
-			seg.outerWidth = outerWidth;
+			seg.outerWidth = outerWidth - opt('eventHorizSpacing');
 			seg.outerHeight = bottom - top;
 			html += slotSegHtml(event, seg);
 		}

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -69,7 +69,8 @@ var defaults = {
 	
 	dropAccept: '*',
 	
-	firstEventLarger: true
+	firstEventLarger: true,
+	eventHorizSpacing: 0
 };
 
 // right-to-left defaults


### PR DESCRIPTION
This is, as #85, the solution from https://code.google.com/p/fullcalendar/issues/detail?id=218#c15, made configurable.

The difference from #85 is that this request also includes a configurable horizontal spacing between events. That means that _either_ this or #85 should be pulled (should any of them be).
