### PR TITLE
Remove event titles text shadow: looks ugly if the text is black

### DIFF
--- a/src/common/common.css
+++ b/src/common/common.css
@@ -143,7 +143,6 @@
 	border: 1px solid #3a87ad; /* default BORDER color */
 	background-color: #3a87ad; /* default BACKGROUND color */
 	color: #fff;               /* default TEXT color */
-	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 	font-size: .85em;
 	cursor: default;
 	}


### PR DESCRIPTION
fc-event text-shadow should not be defined inside FullCalendar. On white text it looks nice, not on black and other colors.
FullCalendar should stay neutral.

With text-shadow:
![With text-shadow](http://img15.hostingpics.net/pics/777559ScreenShot20130327at113811PM.png)

Without:
![Without text-shadow](http://img15.hostingpics.net/pics/138643ScreenShot20130327at113908PM.png)
