### PR TITLE
Update daySelectionMousedown to interpret OSX CTRL + Click as a right mouse click

### DIFF
--- a/src/common/SelectionManager.js
+++ b/src/common/SelectionManager.js
@@ -1,4 +1,3 @@
-
 //BUG: unselect needs to be triggered when events are dragged+dropped
 
 function SelectionManager() {
@@ -69,7 +68,7 @@ function SelectionManager() {
 		var cellIsAllDay = t.cellIsAllDay;
 		var hoverListener = t.getHoverListener();
 		var reportDayClick = t.reportDayClick; // this is hacky and sort of weird
-		if (ev.which == 1 && opt('selectable')) { // which==1 means left mouse button
+		if (ev.which == 1 && opt('selectable') && !ev.ctrlKey) { // which==1 means left mouse button, ctrlKey + left mouse button = osx right click
 			unselect(ev);
 			var _mousedownElement = this;
 			var dates;


### PR DESCRIPTION
When using CTRL + Click in OSX (right click) the selectable feature clears out the currently selected days. Adding !ev.ctrlKey prevents FullCalendar from clearing out the selected days when using CTRL + Click in OSX. 
