### PR TITLE
Optional disable of the today button

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -225,7 +225,7 @@ function Calendar(element, options, eventSources) {
 			
 			header.updateTitle(currentView.title);
 			var today = new Date();
-			if (today >= currentView.start && today < currentView.end) {
+			if (options.disableTodayButton && today >= currentView.start && today < currentView.end) {
 				header.disableButton('today');
 			}else{
 				header.enableButton('today');

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -9,6 +9,7 @@ var defaults = {
 		center: '',
 		right: 'today prev,next'
 	},
+	disableTodayButton: true,
 	weekends: true,
 	weekNumbers: false,
 	weekNumberCalculation: 'iso',


### PR DESCRIPTION
The today button can be enabled on all time if one of the parameters is
true. Can be usefull if the page is open during the night
