### PR TITLE
"Backgroud" typo

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -234,7 +234,7 @@ function EventManager(options, _sources) {
 				e.className = event.className;
 				e.editable = event.editable;
 				e.color = event.color;
-				e.backgroudColor = event.backgroudColor;
+				e.backgroundColor = event.backgroundColor;
 				e.borderColor = event.borderColor;
 				e.textColor = event.textColor;
 				normalizeEvent(e);


### PR DESCRIPTION
Not originally found by myself but [@ChrisHe](https://github.com/stephenharris/Event-Organiser/issues/89). 

But I've not seen any 'symptom' of this bug - Chris found it while scanning the source code.
