### PR TITLE
new: overridablility of formatDates functions

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -22,8 +22,8 @@ function Calendar(element, options, eventSources) {
 	t.today = today;
 	t.gotoDate = gotoDate;
 	t.incrementDate = incrementDate;
-	t.formatDate = function(date, format) { return formatDate(date, format, options) };
-	t.formatDates = function(date1, date2, format) { return formatDates(date1, date2, format, options) };
+	t.formatDate = function(date, format) { return fc.formatDate(date, format, options) };
+	t.formatDates = function(date1, date2, format) { return fc.formatDates(date1, date2, format, options) };
 	t.getDate = getDate;
 	t.getView = getView;
 	t.option = option;

--- a/tests/custom_locale_format.html
+++ b/tests/custom_locale_format.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html>
+  <head>
+
+    <!-- Use case:
+
+         - As a developper, we can easily override the default ``formatDate`` function
+
+         Code Highlights:
+
+         - check the ``changeToCustom()`` javascript function that show how to
+         override formatDates function.
+
+    -->
+
+
+    <link href='../build/out/fullcalendar.css' rel='stylesheet' />
+    <link href='../build/out/fullcalendar.print.css' rel='stylesheet' media='print' />
+    <script src='../build/out/jquery.js'></script>
+    <script src='../build/out/jquery-ui.js'></script>
+    <script src='../build/out/fullcalendar.js'></script>
+    <style>
+
+      .fc .fc-sat, .fc .fc-sun { background-color:red }
+      div#actions { margin: 20px auto; width: 500px; border: 1px dotted red; padding: 10px; text-align: center;}
+    </style>
+    <script type="text/javascript">
+
+      var date = new Date();
+      var d = date.getDate();
+      var m = date.getMonth();
+      var y = date.getFullYear();
+
+      var options = {
+              header: {
+                  left: 'nextYear,next,prev,prevYear today',
+                  center: 'month,agendaWeek,basicWeek,agendaDay,basicDay',
+                  right: 'title prev,next'
+              },
+
+              editable: true,
+
+              firstDay: 1,
+              weekends: false,
+
+              minTime: '8am',
+              maxTime: '11:30pm',
+              firstHour: 9,
+
+              weekMode: 'variable',
+
+              dayClick: function(dayDate, allDay, ev, view) {
+                  console.log('dayClick - ' + dayDate + ' - allDay:' + allDay + ' --- ' + view.title);
+              },
+
+              eventDrop: function(event, dayDelta, minuteDelta, allDay, revertFunc, jsEvent, ui, view) {
+                  console.log('DROP ' + event.title);
+                  console.log(dayDelta + ' days');
+                  console.log(minuteDelta + ' minutes');
+                  console.log('allDay: ' + allDay);
+                  console.log(event.start);
+                  //console.log(minuteDelta + ' minutes');
+              },
+
+              eventResize: function(event, dayDelta, minuteDelta, revertFunc, jsEvent, ui, view) {
+                  console.log('RESIZE!! ' + event.title);
+                  console.log(dayDelta + ' days');
+                  console.log(minuteDelta + ' minutes');
+                  console.log(event.end);
+                  //console.log(minuteDelta + ' minutes');
+              },
+
+              events: [{
+                      title: 'All Day Event',
+                      start: new Date(y, m, 1)
+                  },
+                  {
+                      title: 'Long Event',
+                      start: new Date(y, m, d-5),
+                      end: new Date(y, m, d-2)
+                  },
+                  {
+                      id: 999,
+                      title: 'Repeating Event',
+                      start: new Date(y, m, d-3, 16, 0),
+                      allDay: false
+                  },
+                  {
+                      id: 999,
+                      title: 'Repeating Event',
+                      start: new Date(y, m, d+4, 16, 0),
+                      allDay: false
+                  },
+                  {
+                      title: 'Meeting',
+                      start: new Date(y, m, d, 10, 30),
+                      allDay: false
+                  },
+                  {
+                      title: 'Lunch',
+                      start: new Date(y, m, d, 12, 0),
+                      end: new Date(y, m, d, 14, 0),
+                      allDay: false
+                  },
+                  {
+                      title: 'Birthday Party',
+                      start: new Date(y, m, d+1, 19, 0),
+                      end: new Date(y, m, d+1, 22, 30),
+                      allDay: false
+                  },
+                  {
+                      title: 'Click for Google',
+                      start: new Date(y, m, 28),
+                      end: new Date(y, m, 29),
+                      url: 'http://google.com/'
+                  }
+              ]
+
+          };
+
+      function refreshCalendar(elt) {
+          elt.fullCalendar('destroy');
+          // the ``$.extend`` part is needed until issue #97 is corrected. Link below:
+          // https://github.com/arshaw/fullcalendar/pull/97
+          $('#calendar').fullCalendar($.extend({}, options));
+      }
+
+      // Saving good ol' implementation for the ``changeToDefault`` button action.
+      defaultFormatDate = $.fullCalendar.formatDate;
+      defaultFormatDates = $.fullCalendar.formatDates;
+
+
+      // As a developper, we can easily override the default ``formatDate`` function:
+      function changeToCustom() {
+          $.fullCalendar.formatDate = function (date, format, options) {
+              // dummy function that return format instead of formatted date
+              return format;
+          }
+          $.fullCalendar.formatDates = function (date1, date2, format, options) {
+              // dummy function that return format instead of formatted date
+              return format;
+          };
+          refreshCalendar($('#calendar'));
+      };
+
+      function changeToDefault() {
+          $.fullCalendar.formatDate = defaultFormatDate;
+          $.fullCalendar.formatDates = defaultFormatDates;
+          refreshCalendar($('#calendar'));
+      };
+
+
+      $(document).ready(function() {
+          $('#actions button[name="custom"]').click(changeToCustom)
+          $('#actions button[name="default"]').click(changeToDefault)
+
+          $('#calendar').fullCalendar(options);
+      });
+
+    </script>
+  </head>
+  <body style='font-size:12px'>
+    <div id='actions'>
+      Switch to:
+      <button name="custom">custom mode</button>
+      <button name="default">default mode</button>
+    </div>
+    <div id='calendar' style='width:900px;margin:20px auto 0;font-family:arial'></div>
+  </body>
+</html>


### PR DESCRIPTION
As a developer I need to be able to override `formatDate` or `formatDates` by a custom function from outside fullcalendar, and I cannot find a way to do it. I need to do that because I need to get proper localization support from old [DateJS](http://code.google.com/p/datejs/wiki/FormatSpecifiers), [moment](http://momentjs.com), or even the recent [toLocaleString](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Date/toLocaleString) coming into javascript. 

That's what is possible with my patch:

```
      $.fullCalendar.formatDate = function (date, format, options) {
            // ... my custom function
      }
```

or:

```
      $.fullCalendar.formatDates = function (date1, date2, format, options) {
          // ... my custom function
      };
```

The patch is very small, and I've provided a test/demo file.

Any comments are welcome.
