### PR TITLE
new callback: changeView

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -192,6 +192,8 @@ function Calendar(element, options, eventSources) {
 	
 	function renderView(inc) {
 		if (elementVisible()) {
+			currentView.trigger('changeView', _element); 
+
 			ignoreWindowResize++; // because renderEvents might temporarily change the height before setSize is reached
 
 			unselect();

--- a/tests/triggers.html
+++ b/tests/triggers.html
@@ -44,6 +44,14 @@
 				//console.log(this);
 			},
 
+			changeView: function(view) {
+				console.log('changeView');
+				console.log(view.start + ' - ' + view.end);
+				console.log(view.visStart + ' - ' + view.visEnd);
+				//console.log(view);
+				//console.log(this);
+			},
+
 			eventAfterAllRender: function(view) {
 				console.log('all rendered', view);
 			},


### PR DESCRIPTION
The _changeView_ callback is called **before** a view is changed (as opposite to
_viewDisplay_ which is called after the view has changed). Useful for e.g.
some housekeeping operations before the new view will appear (I need it
for destroying of popovers bound to day cells or event _`<div>`_ elements. If the _viewDisplay_ callback would be used the element the popover is bound to is disconnected from the DOM and the code doesn't work).
