### PR TITLE
Make 'slotNormal' variable in Agenda Views

### DIFF
--- a/src/agenda/AgendaView.js
+++ b/src/agenda/AgendaView.js
@@ -1,4 +1,3 @@
-
 setDefaults({
 	allDaySlot: true,
 	allDayText: 'all-day',
@@ -13,7 +12,8 @@ setDefaults({
 		agenda: .5
 	},
 	minTime: 0,
-	maxTime: 24
+	maxTime: 24,
+	slotNormal: true,
 });
 
 
@@ -190,7 +190,7 @@ function AgendaView(element, calendar, viewName) {
 		var d;
 		var maxd;
 		var minutes;
-		var slotNormal = opt('slotMinutes') % 15 == 0;
+		var slotNormal = opt('slotNormal') === true ? opt('slotMinutes') % 15 == 0 : false;
 		
 		s =
 			"<table style='width:100%' class='fc-agenda-days fc-border-separate' cellspacing='0'>" +


### PR DESCRIPTION
Currently whenever in Agenda Views the time is displayed in every line or not is determined automatically (slotNormal = opt('slotMinutes') % 15 == 0;).

It would be nice, if one could change that by a variable. Hence, only set slotNormal = false and times are also shown for opt('slotMinutes') % 15.

The proposed code shows that only 2 lines would need to be adapted...
