### PR TITLE
beforeViewDisplay trigger

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,4 +1,3 @@
-
  
 function Calendar(element, options, eventSources) {
 	var t = this;
@@ -192,6 +191,7 @@ function Calendar(element, options, eventSources) {
 	
 	function renderView(inc) {
 		if (elementVisible()) {
+			currentView.trigger('viewBeforeDisplay', _element);
 			ignoreWindowResize++; // because renderEvents might temporarily change the height before setSize is reached
 
 			unselect();


### PR DESCRIPTION
This pull request adds a `viewBeforeDisplay` callback, which gets called before the current view is removed and replaced with another view.

Use Case: I've been using the [popover plugin](http://twitter.github.io/bootstrap/javascript.html#popovers) from Twitter Bootstrap to add popovers to events. The popovers are attached to the event element like below:

``` javascript
$('#calendar').fullCalendar({
  eventAfterRender: function(event, element, view) {
    element.popover({
      title: event.title
      content: event.description
    });
  }
});
```

But, I was having an issue where the popovers would get stuck whenever the user paged over to another view. The event elements that the popovers were attached to disappear by the time `viewDisplay` gets called, so there doesn't seem to be a way to hide them after the view changed. Adding the `viewBeforeDisplay` callback makes it easy to clean up anything added to the current view before it changes.

``` javascript
$('#calendar').fullCalendar({
  viewBeforeDisplay: function(view) {
    $('.fc-event').popover('hide');
  }
});
```
