### PR TITLE
Let height property to be defined as a function.

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -242,7 +242,13 @@ function Calendar(element, options, eventSources) {
 			suggestedViewHeight = options.contentHeight;
 		}
 		else if (options.height) {
-			suggestedViewHeight = options.height - (headerElement ? headerElement.height() : 0) - vsides(content);
+			var height;
+			if (typeof(options.height) == 'function') {
+				height = options.height();
+			} else {
+				height = options.height;
+			}
+			suggestedViewHeight = height - (headerElement ? headerElement.height() : 0) - vsides(content);
 		}
 		else {
 			suggestedViewHeight = Math.round(content.width() / Math.max(options.aspectRatio, .5));


### PR DESCRIPTION
People like me might need to change the height of the calendar dynamically and for these situations the best thing is to define height as a function. This pull request just checks if the 'height' property is a function and call it if needed. Very simple and clean.
