### PR TITLE
Allow the user to specify what reference date (or calculation) will be used as a "today" point of reference

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -47,7 +47,7 @@ function Calendar(element, options, eventSources) {
 	var suggestedViewHeight;
 	var resizeUID = 0;
 	var ignoreWindowResize = 0;
-	var date = new Date();
+	var date = option('getDate')();
 	var events = [];
 	var _dragElement;
 	
@@ -364,7 +364,7 @@ function Calendar(element, options, eventSources) {
 
 
 	function updateTodayButton() {
-		var today = new Date();
+		var today = option('getDate')();
 		if (today >= currentView.start && today < currentView.end) {
 			header.disableButton('today');
 		}
@@ -419,7 +419,7 @@ function Calendar(element, options, eventSources) {
 	
 	
 	function today() {
-		date = new Date();
+		date = option('getDate')();
 		renderView();
 	}
 	

--- a/src/agenda/AgendaView.js
+++ b/src/agenda/AgendaView.js
@@ -358,7 +358,7 @@ function AgendaView(element, calendar, viewName) {
 		var headerClass = tm + "-widget-header"; // TODO: make these when updateOptions() called
 		var contentClass = tm + "-widget-content";
 		var date;
-		var today = clearTime(new Date());
+		var today = clearTime(opt('getDate')());
 		var col;
 		var cellsHTML;
 		var cellHTML;

--- a/src/basic/BasicView.js
+++ b/src/basic/BasicView.js
@@ -246,7 +246,7 @@ function BasicView(element, calendar, viewName) {
 	function buildCellHTML(date) {
 		var contentClass = tm + "-widget-content";
 		var month = t.start.getMonth();
-		var today = clearTime(new Date());
+		var today = clearTime(opt('getDate')());
 		var html = '';
 		var classNames = [
 			'fc-day',

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -72,8 +72,11 @@ var defaults = {
 	
 	dropAccept: '*',
 	
-	handleWindowResize: true
+	handleWindowResize: true,
 	
+	getDate: function() {
+		return new Date();
+	}
 };
 
 // right-to-left defaults

--- a/tests/pass_current_date_as_function.html
+++ b/tests/pass_current_date_as_function.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link href='../build/out/fullcalendar.css' rel='stylesheet' />
+<link href='../build/out/fullcalendar.print.css' rel='stylesheet' media='print' />
+<script src='../lib/jquery/jquery.js'></script>
+<script src='../lib/jquery-ui/ui/jquery-ui.js'></script>
+<script src='../build/out/fullcalendar.js'></script>
+<script>
+
+	$(document).ready(function() {
+	
+		var date = new Date();
+		var d = date.getDate();
+		var m = date.getMonth();
+		var y = date.getFullYear();
+		var hrs = date.getHours();
+		var mins = date.getMinutes();
+		var secs = date.getSeconds();
+		
+		$('#calendar').fullCalendar({
+			header: {
+				left: 'prev,next today',
+				center: 'title',
+				right: 'month,agendaWeek,basicWeek,agendaDay,basicDay'
+			},
+			editable: true,
+			events: [
+				{
+					title: 'All Day Event',
+					start: new Date(y, m, 1)
+				},
+				{
+					title: 'Long Event',
+					start: new Date(y, m, d-5),
+					end: new Date(y, m, d-2)
+				},
+				{
+					id: 999,
+					title: 'Repeating Event',
+					start: new Date(y, m, d-3, 16, 0),
+					allDay: false
+				},
+				{
+					id: 999,
+					title: 'Repeating Event',
+					start: new Date(y, m, d+4, 16, 0),
+					allDay: false
+				},
+				{
+					title: 'Meeting',
+					start: new Date(y, m, d, 10, 30),
+					allDay: false
+				},
+				{
+					title: 'Lunch',
+					start: new Date(y, m, d, 12, 5),
+					end: new Date(y, m, d, 14, 43),
+					allDay: false
+				},
+				{
+					title: 'Birthday Party',
+					start: new Date(y, m, d+1, 19, 0),
+					end: new Date(y, m, d+1, 22, 30),
+					allDay: false
+				},
+				{
+					title: 'Click for Google',
+					start: new Date(y, m, 28),
+					end: new Date(y, m, 29),
+					url: 'http://google.com/'
+				}
+			],
+			getDate: function() {
+				return new Date(y, m, d+7, hrs, mins, secs, 0);
+			}
+		});
+		
+	});
+
+</script>
+<style>
+
+	body {
+		margin-top: 40px;
+		text-align: center;
+		font-size: 13px;
+		font-family: "Lucida Grande",Helvetica,Arial,Verdana,sans-serif;
+		}
+
+	#calendar {
+		width: 900px;
+		margin: 0 auto;
+		}
+
+</style>
+</head>
+<body>
+<p>"Today" has been moved one week into the future!</p>
+<div id='calendar'></div>
+</body>
+</html>


### PR DESCRIPTION
Allow the user to specify what reference date (or calculation) will be used as a "today" point of reference.

Defaults to browser's default date.

Useful for applications that will perform timezone conversions and where "today" may not be what the browser returns.
