### PR TITLE
Added a check that getDaySegmentContainer isn't undefined when clearEvents is called.

### DIFF
--- a/src/basic/BasicEventRenderer.js
+++ b/src/basic/BasicEventRenderer.js
@@ -18,9 +18,9 @@ function BasicEventRenderer() {
 	
 	
 	function clearEvents() {
-        if (t.getDaySegmentContainer() !== undefined) {
-            t.getDaySegmentContainer().empty();
-        }
+		if (t.getDaySegmentContainer() !== undefined) {
+			t.getDaySegmentContainer().empty();
+		}
 	}
 
 


### PR DESCRIPTION
I use the calendar along with bootstrap tabs and AngularJS and AngularUI. The calendar is placed in a tab that is isn't active from the start and is render when the calendar tab is clicked. I added this check to get rid of the error _TypeError: Cannot call method 'empty' of undefined_ of the `getDaySegmentContainer`. However, this might not be a general problem.

Anyway, thanks for a great calendar.
// John
