### PR TITLE
Add support for double clicking day slots

### DIFF
--- a/src/agenda/AgendaView.js
+++ b/src/agenda/AgendaView.js
@@ -545,6 +545,7 @@ function AgendaView(element, calendar, viewName) {
 	
 	function slotClick(ev) {
 		if (!opt('selectable')) { // if selectable, SelectionManager will worry about dayClick
+			var eventName = 'day' + (ev.type == 'dblclick' ? 'DoubleClick' : 'Click');
 			var col = Math.min(colCnt-1, Math.floor((ev.pageX - dayTable.offset().left - axisWidth) / colWidth));
 			var date = cellToDate(0, col);
 			var rowMatch = this.parentNode.className.match(/fc-slot(\d+)/); // TODO: maybe use data
@@ -553,9 +554,9 @@ function AgendaView(element, calendar, viewName) {
 				var hours = Math.floor(mins/60);
 				date.setHours(hours);
 				date.setMinutes(mins%60 + minMinute);
-				trigger('dayClick', dayBodyCells[col], date, false, ev);
+				trigger(eventName, dayBodyCells[col], date, false, ev);
 			}else{
-				trigger('dayClick', dayBodyCells[col], date, true, ev);
+				trigger(eventName, dayBodyCells[col], date, true, ev);
 			}
 		}
 	}

--- a/src/agenda/AgendaView.js
+++ b/src/agenda/AgendaView.js
@@ -531,13 +531,15 @@ function AgendaView(element, calendar, viewName) {
 
 	function dayBind(cells) {
 		cells.click(slotClick)
-			.mousedown(daySelectionMousedown);
+			.mousedown(daySelectionMousedown)
+			.dblclick(slotClick);
 	}
 
 
 	function slotBind(cells) {
 		cells.click(slotClick)
-			.mousedown(slotSelectionMousedown);
+			.mousedown(slotSelectionMousedown)
+			.dblclick(slotClick);
 	}
 	
 	

--- a/tests/daydoubleclick.html
+++ b/tests/daydoubleclick.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link href='../build/out/fullcalendar.css' rel='stylesheet' />
+<link href='../build/out/fullcalendar.print.css' rel='stylesheet' media='print' />
+<script src='../lib/jquery/jquery.js'></script>
+<script src='../lib/jquery-ui/ui/jquery-ui.js'></script>
+<script src='../build/out/fullcalendar.js'></script>
+<script>
+
+	$(document).ready(function() {
+
+		var date = new Date();
+		var d = date.getDate();
+		var m = date.getMonth();
+		var y = date.getFullYear();
+
+		$('#calendar').fullCalendar({
+			header: {
+				left: 'prev,next today',
+				center: 'title',
+				right: 'month,agendaWeek,agendaDay,basicDay'
+			},
+			dayDoubleClick: function() {
+				alert('Day double clicked!');
+				console.log(arguments);
+			},
+			editable: true,
+			events: [
+				{
+					title: 'All Day Event',
+					start: new Date(y, m, 1)
+				},
+				{
+					title: 'Long Event',
+					start: new Date(y, m, d-5),
+					end: new Date(y, m, d-2)
+				},
+				{
+					id: 999,
+					title: 'Repeating Event',
+					start: new Date(y, m, d-3, 16, 0),
+					allDay: false
+				},
+				{
+					id: 999,
+					title: 'Repeating Event',
+					start: new Date(y, m, d+4, 16, 0),
+					allDay: false
+				},
+				{
+					title: 'Meeting',
+					start: new Date(y, m, d, 10, 30),
+					allDay: false
+				},
+				{
+					title: 'Lunch',
+					start: new Date(y, m, d, 12, 5),
+					end: new Date(y, m, d, 14, 43),
+					allDay: false
+				},
+				{
+					title: 'Birthday Party',
+					start: new Date(y, m, d+1, 19, 0),
+					end: new Date(y, m, d+1, 22, 30),
+					allDay: false
+				},
+				{
+					title: 'Click for Google',
+					start: new Date(y, m, 28),
+					end: new Date(y, m, 29),
+					url: 'http://google.com/'
+				}
+			]
+		});
+	});
+
+</script>
+<style>
+
+	body {
+		margin-top: 40px;
+		text-align: center;
+		font-size: 13px;
+		font-family: "Lucida Grande",Helvetica,Arial,Verdana,sans-serif;
+		}
+
+	#calendar {
+		width: 900px;
+		margin: 0 auto;
+		}
+
+</style>
+</head>
+<body>
+<div id='calendar'></div>
+</body>
+</html>


### PR DESCRIPTION
Double click events are fired only on calendar events. This changeset provides a `dayDoubleClick` event to listen to, just like `dayClick` does.

feature request ticket: #638 (for both events and day slots)