### PR TITLE
issue 1996 zooming calendar causes events to miss-align

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -43,7 +43,6 @@ function Calendar(element, options, eventSources) {
 	var content;
 	var tm; // for making theme classes
 	var currentView;
-	var elementOuterWidth;
 	var suggestedViewHeight;
 	var resizeUID = 0;
 	var ignoreWindowResize = 0;
@@ -263,7 +262,6 @@ function Calendar(element, options, eventSources) {
 		currentView.setWidth(content.width());
 		ignoreWindowResize--;
 
-		elementOuterWidth = element.outerWidth();
 	}
 	
 	
@@ -273,12 +271,10 @@ function Calendar(element, options, eventSources) {
 				var uid = ++resizeUID;
 				setTimeout(function() { // add a delay
 					if (uid == resizeUID && !ignoreWindowResize && elementVisible()) {
-						if (elementOuterWidth != (elementOuterWidth = element.outerWidth())) {
-							ignoreWindowResize++; // in case the windowResize callback changes the height
-							updateSize();
-							currentView.trigger('windowResize', _element);
-							ignoreWindowResize--;
-						}
+						ignoreWindowResize++; // in case the windowResize callback changes the height
+						updateSize();
+						currentView.trigger('windowResize', _element);
+						ignoreWindowResize--;
 					}
 				}, 200);
 			}else{


### PR DESCRIPTION
The window resize handler cannot accurately determine when the calendar has "changed size" by checking its width during a zoom operation because in fact the browser reports the same width +/- 0.999px somewhat randomly (at least chrome and IE8 behave this way). Since the "skipping a fc redraw" optimization didn't really seem to buy anything, I suggest removing it.

If the optimization is important, then consider tracking something that affects the layout of events, perhaps the top offset of the last time-slot.

Aside: the 200 ms wait is probably not necessary either. Consider waiting 1ms, which will allow the browser to finish rendering and not add any additional/unnecessary delay.

RE: https://code.google.com/p/fullcalendar/issues/detail?id=1996
