### PR TITLE
Enable sorting of events manually with event.priority

### DIFF
--- a/src/common/DayEventRenderer.js
+++ b/src/common/DayEventRenderer.js
@@ -1,4 +1,3 @@
-
 function DayEventRenderer() {
 	var t = this;
 
@@ -743,7 +742,8 @@ function segmentElementEach(segments, callback) { // TODO: use in AgendaView?
 
 // A cmp function for determining which segments should appear higher up
 function compareDaySegments(a, b) {
-	return (b.rightCol - b.leftCol) - (a.rightCol - a.leftCol) || // put wider events first
+	return (b.event.priority || 0) - (a.event.priority || 0) || // put higher priority events first
+		(b.rightCol - b.leftCol) - (a.rightCol - a.leftCol) || // if tie, put wider events first
 		b.event.allDay - a.event.allDay || // if tie, put all-day events first (booleans cast to 0/1)
 		a.event.start - b.event.start || // if a tie, sort by event start date
 		(a.event.title || '').localeCompare(b.event.title) // if a tie, sort by event title


### PR DESCRIPTION
Allow us to override sorting of events using a `event.priority` attribute. A use case for this is when we want to separate groups of events such as active vs. inactive.
