### PR TITLE
Don't trigger both day click and drag events at once

### DIFF
--- a/src/agenda/AgendaView.js
+++ b/src/agenda/AgendaView.js
@@ -827,6 +827,7 @@ function AgendaView(element, calendar, viewName) {
 		if (ev.which == 1 && opt('selectable')) { // ev.which==1 means left mouse button
 			unselect(ev);
 			var dates;
+			var previousY = ev.clientY;
 			hoverListener.start(function(cell, origCell) {
 				clearSelection();
 				if (cell && cell.col == origCell.col && !getIsCellAllDay(cell)) {
@@ -844,12 +845,16 @@ function AgendaView(element, calendar, viewName) {
 				}
 			}, ev);
 			$(document).one('mouseup', function(ev) {
+				var distanceY = Math.abs(ev.clientY - previousY);
 				hoverListener.stop();
 				if (dates) {
-					if (+dates[0] == +dates[1]) {
+					if (+dates[0] == +dates[1] && distanceY < opt('mouseThreshold')) {
+						clearSelection();
 						reportDayClick(dates[0], false, ev);
 					}
-					reportSelection(dates[0], dates[3], false, ev);
+					else {
+						reportSelection(dates[0], dates[3], false, ev);
+					}
 				}
 			});
 		}

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -69,6 +69,7 @@ var defaults = {
 	
 	//selectable: false,
 	unselectAuto: true,
+        mouseThreshold: 4,
 	
 	dropAccept: '*',
 	


### PR DESCRIPTION
I needed to distinguish between day click and drag events in my application.  I needed the following behavior:
- When a day is clicked, a dialog pops up with a pre-filled start time field but a blank end time field
- When a day is dragged on, a dialog pops up with a pref-filled start time field and a pre-filled end time field

This adds a configurable `mouseThreshold` option allowing clicks to be distinguished from drags.  The existing behavior can be used by defaulting `mouseThreshold` to `0` (for backwards compatibility).

There's probably a better way to do this, but this method has worked great for my needs.  Thoughts on this implementation?
