### PR TITLE
added eventDropRevert and eventResizeRevert event.

### DIFF
--- a/src/common/View.js
+++ b/src/common/View.js
@@ -210,6 +210,7 @@ function View(element, calendar, viewName) {
 			function() {
 				// TODO: investigate cases where this inverse technique might not work
 				moveEvents(eventsByID[eventId], -dayDelta, -minuteDelta, oldAllDay);
+                trigger('eventDropRevert', e, event, -dayDelta, -minuteDelta, oldAllDay, ev, ui);
 				reportEventChange(eventId);
 			},
 			ev,
@@ -217,8 +218,8 @@ function View(element, calendar, viewName) {
 		);
 		reportEventChange(eventId);
 	}
-	
-	
+
+
 	function eventResize(e, event, dayDelta, minuteDelta, ev, ui) {
 		var eventId = event._id;
 		elongateEvents(eventsByID[eventId], dayDelta, minuteDelta);
@@ -231,6 +232,7 @@ function View(element, calendar, viewName) {
 			function() {
 				// TODO: investigate cases where this inverse technique might not work
 				elongateEvents(eventsByID[eventId], -dayDelta, -minuteDelta);
+                trigger('eventResizeRevert', e, event, -dayDelta, -minuteDelta, ev, ui);
 				reportEventChange(eventId);
 			},
 			ev,


### PR DESCRIPTION
Added two new callbacks to the event dragging and resizing part:
- eventDropRevert
- eventResizeRevert

These events allow to listen to whether the revertFunc function has been called. This is especially useful if undo functionality is provided with the help of the revertFunc, as this function already has the dayDelta and minutesDelta and they needn't be stored otherwise. 
The new callbacks expose the same attributes as the base callbacks, i.e. for eventDropRevert the same as for eventDrop and for eventResizeRevert the same as eventResize, minus the revertFunc function.
