### PR TITLE
cloneDate for rangeStart / rangeEnd

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -1,4 +1,3 @@
-
 fc.sourceNormalizers = [];
 fc.sourceFetchers = [];
 
@@ -58,8 +57,8 @@ function EventManager(options, _sources) {
 	
 	
 	function fetchEvents(start, end) {
-		rangeStart = start;
-		rangeEnd = end;
+		rangeStart = cloneDate(start);
+		rangeEnd = cloneDate(end);
 		cache = [];
 		var fetchID = ++currentFetchID;
 		var len = sources.length;


### PR DESCRIPTION
"start" and "end" should be cloned. Causes unintended change of "rangeStart" (and "rangeEnd"), thereby not fetching events in the first time when clicking "prev"
