### PR TITLE
Added missing calendar initialization to buttonText test

### DIFF
--- a/tests/automated/buttonText.js
+++ b/tests/automated/buttonText.js
@@ -17,6 +17,8 @@ describe('button text', function() {
 
     describe('when lang is default', function() {
       it('should have no text', function() {
+        $('#cal').fullCalendar();
+
         expect($('.fc-button-next')).toHaveText('');
         expect($('.fc-button-nextYear')).toHaveText('');
         expect($('.fc-button-prev')).toHaveText('');


### PR DESCRIPTION
Sorry... noticed I forgot the calendar init in one of my tests. I've reviewed all of them and it's all good now.
