### PR TITLE
Testing the names of all weekdays in the month, agendaView and weekView views

### DIFF
--- a/demos/default.html
+++ b/demos/default.html
@@ -15,7 +15,6 @@
 		$('#calendar').fullCalendar({
 			defaultDate: '2014-01-12',
 			editable: true,
-      weekends: false,
 			events: [
 				{
 					title: 'All Day Event',

--- a/tests/automated/dayNamesShort.js
+++ b/tests/automated/dayNamesShort.js
@@ -4,7 +4,7 @@ describe('short day names', function() {
     'month',
     'agendaWeek',
     'basicWeek',
-  ]
+  ];
   var dayClasses = [
     '.fc-sun',
     '.fc-mon',
@@ -18,8 +18,7 @@ describe('short day names', function() {
 
   beforeEach(function() {
     affix('#cal');
-    settings = {
-    }
+    settings = { };
   });
 
   testableClasses.forEach(function(viewClass, index, viewClasses) {
@@ -27,44 +26,44 @@ describe('short day names', function() {
       beforeEach(function() {
         settings.defaultView = viewClass;
       });
-  
+
       describe('when lang is default', function() {
         it('should be in English', function() {
           moment.lang('en');
           $('#cal').fullCalendar(settings);
           var weekdays = moment.weekdaysShort();
-  
+
           dayClasses.forEach(function(cls, index, classes) {
             expect($('.fc-view thead ' + cls)[0]).toContainText(weekdays[index]);
           });
         });
       });
-    
+
       describe('when lang is not default', function() {
         languages.forEach(function(language, index, languages) {
           it('should be in the selected language', function() {
             settings.lang = language;
             $('#cal').fullCalendar(settings);
-    
+
             moment.lang(language);
-            var dow = moment.langData(language)._week.dow
+            var dow = moment.langData(language)._week.dow;
             var weekdays = moment.weekdaysShort();
-    
+
             dayClasses.forEach(function(cls, index, classes) {
               expect($('.fc-view thead ' + cls)[0]).toContainText(weekdays[index]);
             });
           });
         });
       });
-    
+
       describe('when specified', function() {
         it('should contain the specified names in the given order', function() {
           var days = [
-            'Hovjaj', 'maSjaj', 'veSjaj', 'mechjaj', 'parmaqjaj', 'HoSjaj'
-          ]
+            'Hov.', 'maS.', 'veS.', 'mech.', 'parmaq.', 'HoS.'
+          ];
           settings.dayNamesShort = days;
           $('#cal').fullCalendar(settings);
-  
+
           dayClasses.forEach(function(cls, index, classes) {
             expect($('.fc-view thead ' + cls)[0]).toContainText(days[index]);
           });


### PR DESCRIPTION
For the `month`, `agendaView` and `weekView` views I'm just looking at the first (and most likely only) element that fits the `.fc-view thead .fc-DAY` selector. From that point onwards I check the contents of every weekday header because the tests are similar for all views I've taken the liberty to throw them in a `forEach` loop. Not sure if it is acceptable, but it makes for less SLOC.
