### PR TITLE
Trigger events on the calendar

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -699,10 +699,12 @@ function Calendar(element, instanceOptions) {
 	
 	
 	function trigger(name, thisObj) {
+		var extraParameters = Array.prototype.slice.call(arguments, 2);
+		$(_element).trigger('fullcalendar-' + name, extraParameters);
 		if (options[name]) {
 			return options[name].apply(
 				thisObj || _element,
-				Array.prototype.slice.call(arguments, 2)
+				extraParameters
 			);
 		}
 	}


### PR DESCRIPTION
Although there are settings to set the callback functions for some events, would be useful if all events were fired, regardless of the setting. 
Thus we have the freedom to listen to the elements and can perform certain tasks, even when we can not change the setting of callbacks.
