### PR TITLE
Relative path in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,8 +20,8 @@
   },
 
   "main": [
-    "/dist/fullcalendar.js",
-    "/dist/fullcalendar.css"
+    "dist/fullcalendar.js",
+    "dist/fullcalendar.css"
   ],
   "ignore": [
     "*",


### PR DESCRIPTION
Changed the paths in `bower.json` from _absolute_ to _relative_.
Thx for **fullcalendar** btw :)
