### PR TITLE
Update bower.json to relative file paths for main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,8 +20,8 @@
   },
 
   "main": [
-    "/dist/fullcalendar.js",
-    "/dist/fullcalendar.css"
+    "./dist/fullcalendar.js",
+    "./dist/fullcalendar.css"
   ],
   "ignore": [
     "*",


### PR DESCRIPTION
When using a Gulp plugin that automatically determine files in the 'main' property, this value breaks down because it ends up looking for an absolute path. This should fix it.
