### PR TITLE
add title attribute to 'fc-time' and 'fc-title'

### DIFF
--- a/dist/fullcalendar.js
+++ b/dist/fullcalendar.js
@@ -5162,12 +5162,12 @@ $.extend(DayGrid.prototype, {
 
 		// Only display a timed events time if it is the starting segment
 		if (!event.allDay && seg.isStart) {
-			timeHtml = '<span class="fc-time">' +'title="'+event.title+'">' + htmlEscape(view.getEventTimeText(event)) + '</span>';
+			timeHtml = '<span class="fc-time">' + 'title="'+event.title+'">' + htmlEscape(view.getEventTimeText(event)) + '</span>';
 		}
 
 		titleHtml =
-			'<span class="fc-title">' +'title="'+event.title+'">' +
-				(htmlEscape(event.title || '') || '&nbsp;') + // we always want one line of height
+			'<span class="fc-title">' + 'title="'+event.title+'">' +
+			 (htmlEscape(event.title || '') || '&nbsp;') + // we always want one line of height
 			'</span>';
 		
 		return '<a class="' + classes.join(' ') + '"' +


### PR DESCRIPTION
When I first used fullcalendar,I found if the event's content is long,some content will be hidden  on the calendar.So I think adding the 'title' attribute will be better when the long content is hidden,we can use mouse hover on  the content,and the full content will be shown.
