### PR TITLE
Fixed Google Calendar Remove Source

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -307,7 +307,7 @@ function EventManager(options) { // assumed to be a calendar
 	function getSourcePrimitive(source) {
 		return (
 			(typeof source === 'object') ? // a normalized event source?
-				(source.origArray || source.url || source.events) : // get the primitive
+				(source.origArray || source.url || source.googleCalendarId || source.events) : // get the primitive
 				null
 		) ||
 		source; // the given argument *is* the primitive


### PR DESCRIPTION
This fixes a bug that wouldn't allow removing a source when using Google Calendar.
