### PR TITLE
Fix problem with function prototype inheritance in some older versions of Webkit

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -494,7 +494,7 @@ function createObject(proto) {
 
 function copyOwnProps(src, dest) {
 	for (var name in src) {
-		if (hasOwnProp(src, name)) {
+		if (name !== 'prototype' && hasOwnProp(src, name)) {
 			dest[name] = src[name];
 		}
 	}


### PR DESCRIPTION
Observed behavior is in wkhtmltopdf 0.10.0 rc2.

Behavior stems from the fact that `for (name in [function])`, will include the functions prototype in some versions of Webkit. In later versions of Webkit the prototype member is never iterated over.

The problem that this was causing in fullcalendar is that copying a function's `prototype` into another function will cause the unexpected behavior of new instances not using to establish object members.

It's unclear when this behavior changed, but this patch provides backward compatibility for the older behavior.

[Related StackOverflow with more detailed explanation of observed Webkit behavior](http://stackoverflow.com/questions/28708224/strange-behavior-function-prototype-not-iterable-until-referenced).