### PR TITLE
add week to similarUnitMap used for formatRange (also fixes issue 2371)

### DIFF
--- a/src/date-formatting.js
+++ b/src/date-formatting.js
@@ -150,6 +150,8 @@ function formatRangeWithChunks(date1, date2, chunks, separator, isRTL) {
 var similarUnitMap = {
 	Y: 'year',
 	M: 'month',
+	w: 'week', // week of year
+	W: 'week', // week of year (ISO)
 	D: 'day', // day of month
 	d: 'day', // day of week
 	// prevents a separator between anything time-related...
@@ -162,7 +164,6 @@ var similarUnitMap = {
 	m: 'second', // minute
 	s: 'second' // second
 };
-// TODO: week maybe?
 
 
 // Given a formatting chunk, and given that both dates are similar in the regard the

--- a/tests/automated/formatRange.js
+++ b/tests/automated/formatRange.js
@@ -41,6 +41,11 @@ describe('formatRange', function() {
 		expect(s).toEqual('January 1st 2014');
 	});
 
+	it('outputs the single week number when dates have the same week and format string is week', function() {
+		var s = $.fullCalendar.formatRange('2014-01-01', '2014-01-01', 'W');
+		expect(s).toEqual('1');
+	});
+
 	it('uses a custom separator', function() {
 		var s = $.fullCalendar.formatRange(
 			'2014-01-01T06:00:00',


### PR DESCRIPTION
fixes the problem stated here: https://code.google.com/p/fullcalendar/issues/detail?id=2371&q=duplicate%20title&colspec=ID%20Type%20Status%20Milestone%20Summary%20Stars