### PR TITLE
renderEvent when event.source specified doesn't display the event

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -373,8 +373,8 @@ function EventManager(options) { // assumed to be a calendar
 						stickySource.events.push(event);
 						event.source = stickySource;
 					}
-					cache.push(event);
 				}
+				cache.push(event);
 			}
 
 			reportEvents(cache);


### PR DESCRIPTION
Issue: https://code.google.com/p/fullcalendar/issues/detail?id=2540

Apologies, I'm relatively new to fullCalendar (which is fabulous!!)

Calling renderEvent with sticky=false and an event.source specified seems to skip adding the event to the internal cache and thus never displays the event, even though it seems that was a legal, and anticipated scenario.

Could the problem be that the cache.push(event) at EventManager.js:376 is slightly misplaced inside the test for !event.source (:371)? Moving the push outside the if seems to make everything much happier, but I didn't want to submit a pull request until folks more knowledgeable than I had a chance to review the issue!

Thanks so much and apologies if I've gotten this completely wrong!
