### PR TITLE
Option to set a day break time for TimeGrid

### DIFF
--- a/src/common/TimeGrid.events.js
+++ b/src/common/TimeGrid.events.js
@@ -93,8 +93,8 @@ TimeGrid.mixin({
 
 		for (i = 0; i < segs.length; i++) {
 			seg = segs[i];
-			seg.top = this.computeDateTop(seg.start, seg.start);
-			seg.bottom = this.computeDateTop(seg.end, seg.start);
+			seg.top = this.computeDateTop(seg.start, this.colDates[seg.col]);
+			seg.bottom = this.computeDateTop(seg.end, this.colDates[seg.col]);
 		}
 	},
 

--- a/src/common/TimeGrid.js
+++ b/src/common/TimeGrid.js
@@ -8,6 +8,7 @@ var TimeGrid = Grid.extend({
 	snapDuration: null, // granularity of time for dragging and selecting
 	minTime: null, // Duration object that denotes the first visible time of any given day
 	maxTime: null, // Duration object that denotes the exclusive visible end time of any given day
+	dayBreakTime: null, // the time when we should break for a new day (NOTE: Overrides minTime and maxTime)
 	colDates: null, // whole-day dates for each column. left to right
 	axisFormat: null, // formatting string for times running along vertical axis
 
@@ -114,6 +115,7 @@ var TimeGrid = Grid.extend({
 		var view = this.view;
 		var slotDuration = view.opt('slotDuration');
 		var snapDuration = view.opt('snapDuration');
+		var dayBreakTime = view.opt('dayBreakTime');
 
 		slotDuration = moment.duration(slotDuration);
 		snapDuration = snapDuration ? moment.duration(snapDuration) : slotDuration;
@@ -122,8 +124,9 @@ var TimeGrid = Grid.extend({
 		this.snapDuration = snapDuration;
 		this.cellDuration = snapDuration; // for Grid system
 
-		this.minTime = moment.duration(view.opt('minTime'));
-		this.maxTime = moment.duration(view.opt('maxTime'));
+		this.dayBreakTime = moment.duration(dayBreakTime);
+		this.minTime = dayBreakTime ? this.dayBreakTime : moment.duration(view.opt('minTime'));
+		this.maxTime = dayBreakTime ? moment.duration('24:00:00').add(this.dayBreakTime) : moment.duration(view.opt('maxTime'));
 
 		this.axisFormat = view.opt('axisFormat') || view.opt('smallTimeFormat');
 	},


### PR DESCRIPTION
Accepted in: https://code.google.com/p/fullcalendar/issues/detail?id=2541

Setting the new option dayBreakTime to for example "07:00" or "7:00 AM" will make the day columns in TimeGrid views start at 7 am in the morning and extend past midnight, ending 7 am the following day. This can be useful for TV-listings or concert/club event scheduling were it's common to have "days" ending past midnight.

This is accomplished with two small code changes.

1) Make sure we actually use the seg column date as the startOfDayDate property in computeSegVerticals() instead of the seg event start date.

2) Add a dayBreakTime option which overrides the minTime and maxTime values to make the columns render past midnight.

Example;

$('#calendar').fullCalendar({
   header: {
      left: 'prev,next today',
      center: 'title',
      right: 'month,agendaWeek,agendaDay'
   },
   defaultView: 'agendaWeek',
   dayBreakTime: "07:00",
   ...
});