### PR TITLE
Firing event-click for bg events

### DIFF
--- a/src/common/Grid.events.js
+++ b/src/common/Grid.events.js
@@ -215,6 +215,30 @@ Grid.mixin({
 			}
 		);
 	},
+	
+	bindBgSegHandlers: function() {
+		var _this = this;
+		var view = this.view;
+
+		$.each(
+			{
+				click: function(seg, ev) {
+					return view.trigger('bgEventClick', this, seg.event, ev); // can return `false` to cancel
+				}
+			},
+			function(name, func) {
+				// attach the handler to the container element and only listen for real event elements via bubbling
+				_this.el.on(name, '.fc-bgevent-container > *', function(ev) {
+					var seg = $(this).data('fc-seg'); // grab segment data. put there by View::renderEvents
+
+					// only call the handlers if there is not a drag/resize in progress
+					if (seg && !_this.isDraggingSeg && !_this.isResizingSeg) {
+						return func.call(this, seg, ev); // `this` will be the event element
+					}
+				});
+			}
+		);
+	},
 
 
 	// Updates internal state and triggers handlers for when an event element is moused over

--- a/src/common/Grid.js
+++ b/src/common/Grid.js
@@ -296,6 +296,7 @@ var Grid = fc.Grid = RowRenderer.extend({
 		// attach event-element-related handlers. in Grid.events
 		// same garbage collection note as above.
 		this.bindSegHandlers();
+		this.bindBgSegHandlers();
 
 		this.bindGlobalHandlers();
 	},
@@ -575,6 +576,7 @@ var Grid = fc.Grid = RowRenderer.extend({
 
 					// correct element type? (would be bad if a non-TD were inserted into a table for example)
 					if (el.is(_this.fillSegTag)) {
+						el.data('fc-seg', seg); // used by handlers
 						seg.el = el;
 						renderedSegs.push(seg);
 					}


### PR DESCRIPTION
Accepted in: https://code.google.com/p/fullcalendar/issues/detail?id=2543

In some cases it's useful to detect clicks on background events (not currently supported).

The small fix is divided into two parts;

1) Make sure we connect the seg to the fillSeg by fc-seg data in renderFillSegEls() in Grid.js, just like we do for ordinary event segs.

2) Detect click events on .fc-bgevent-container elements and trigger bgEventClick in a new bindBgSegHandlers method.

We could extend the bindSegHandlers method to support bg events too, but the new method felt cleaner since we don't want to resize the background events.

Example;

$('#calendar').fullCalendar({
   header: {
      left: 'prev,next today',
      center: 'title',
      right: 'month,agendaWeek,agendaDay'
   },
   defaultView: 'agendaWeek',
   bgEventClick: function(calEvent, jsEvent, view) {
      alert(calEvent.title);	
   },
   ...
});