### PR TITLE
ensure header elements are always equally spaced

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -29,7 +29,23 @@
 .fc .fc-toolbar > * > :first-child { /* extra precedence to override button border margins */
 	margin-left: 0;
 }
-	
+
+.fc .fc-toolbar > * > button + h2 {
+	margin: 0 .75em;
+}
+
+.fc .fc-toolbar > * > h2 + button {
+	margin-left: 0;
+}
+
+.fc .fc-toolbar > * > h2:first-child {
+	margin-right: .75em;
+}
+
+.fc .fc-toolbar > * > h2:last-child {
+	margin-right: 0;
+}
+
 /* title text */
 
 .fc-toolbar h2 {

--- a/src/main.css
+++ b/src/main.css
@@ -22,7 +22,7 @@
 /* the things within each left/right/center section */
 .fc .fc-toolbar > * > * { /* extra precedence to override button border margins */
 	float: left;
-	margin-left: .75em;
+	margin-left: .75rem;
 }
 
 /* the first thing within each left/center/right section */

--- a/src/main.css
+++ b/src/main.css
@@ -22,7 +22,7 @@
 /* the things within each left/right/center section */
 .fc .fc-toolbar > * > * { /* extra precedence to override button border margins */
 	float: left;
-	margin-left: .75rem;
+	margin-left: .75em;
 }
 
 /* the first thing within each left/center/right section */


### PR DESCRIPTION
FullCalendar CSS gives all header elements a left margin of 0.75em.

With a header config of:

```
header: {
    left: '',
    center: 'prev title next',
    right: ''
},
```

the `title` is an `<h2>`, giving a calculated font-size of 1.5em, while the `prev` and `next` buttons have a `.fc button` font-size of 1em.

This causes the title to have a larger left margin because its font-size is bigger. Setting header element left margins to 0.75**r**em ensures that all header elements will have equal spacing based on the root document font-size.
