### PR TITLE
Adapt lang.js test to changed Moment locale for es

### DIFF
--- a/tests/automated/lang.js
+++ b/tests/automated/lang.js
@@ -15,7 +15,7 @@ describe('lang', function() {
 		expect(s).toEqual('Thursday May 1st 2014');
 	});
 
-	it('is not affected by global moment lang when unset', function() {
+	it('is not affected by global moment lang when set', function() {
 		moment.lang('fr');
 		affix('#cal');
 		$('#cal').fullCalendar({

--- a/tests/automated/lang.js
+++ b/tests/automated/lang.js
@@ -24,7 +24,7 @@ describe('lang', function() {
 		var calendar = $('#cal').fullCalendar('getCalendar');
 		var mom = calendar.moment('2014-05-01');
 		var s = mom.format('dddd MMMM Do YYYY');
-		expect(s).toEqual('jueves mayo 1º 2014');
+		expect(s).toEqual('Jueves Mayo 1º 2014');
 	});
 
 	it('doesn\'t side-effect the global moment lang when customized', function() {


### PR DESCRIPTION
Moment.js made changes to its Spanish locale in [version 2.10.3][1], 
switching to capitalized month and weekday names.

These two commits:
- Update the test for lang.js to expect the new format, and
- Fix a probable typo in the title of the test spec.

[1]: https://github.com/moment/moment/commit/25cc720fbaab7323a1016cd0beb6a36e349c41be