### PR TITLE
Adapt generateLanguages to changed Moment locales

### DIFF
--- a/build/tasks/generateLanguages.js
+++ b/build/tasks/generateLanguages.js
@@ -133,12 +133,18 @@ module.exports = function(grunt) {
 			}
 		);
 
-		// replace the `return` statement so execution continues
-		// compatible with moment-pre-2.8
+		// remove the var/return wrap
+		var lc;
 		js = js.replace(
-			/^(\s*)return moment\.(defineLocale|lang)\(/m,
-			'$1(moment.defineLocale || moment.lang).call(moment, '
+			/^(\s*)var (\w*) = moment\.(defineLocale|lang)\(/m,
+			function(m0, p1, p2) {
+				lc = p2;
+				var rs = p1 + '(moment.defineLocale || moment.lang).call(moment, ';
+				return rs;
+			}
 		);
+		var re = new RegExp('^(\s*)return ' + lc + ';', 'm');
+		js = js.replace(re, '$1');
 
 		return js;
 	}


### PR DESCRIPTION
Since around version 2.10.0, the [structure of Moment.js locale files
has changed][1], assigning the result of `moment.defineLocale()` to an
intermediate variable before returning it.

This commit changes the regular expressions in FullCalendar's
`generateLanguages` script to expect the new format.

In my setup, this patch by itself on current master reduces the number 
of failing tests from 20 to 2.

Closes fullcalendar/fullcalendar#2980

I think this also removes the need for [commit 3fd5318][2] of pull 
request fullcalendar/fullcalendar#2918, but do note that that request 
contains another commit as well.

[1]: https://github.com/moment/moment/commit/446cee8ca024507f06ec8d6f7bef361458c70cae/locale/fr.js#diff-2bc288913ddf5c7036261781142e800a
[2]: https://github.com/Tarabyte/fullcalendar/commit/3fd53185c67f01afd3441ecd4a20bd62df8f5ed1