### PR TITLE
Adapt eventDrop test to change in Moment durations

### DIFF
--- a/tests/automated/event-dnd.js
+++ b/tests/automated/event-dnd.js
@@ -225,8 +225,8 @@ describe('eventDrop', function() {
 						});
 					},
 					function(event, delta, revertFunc) {
-						expect(delta.days()).toBe(-1);
-						expect(delta.hours()).toBe(1);
+						expect(delta.days()).toBe(0);
+						expect(delta.hours()).toBe(-23);
 						expect(delta.minutes()).toBe(0);
 						expect(delta.seconds()).toBe(0);
 						expect(delta.milliseconds()).toBe(0);


### PR DESCRIPTION
Moment 2.10.5 included a [change in duration bubbling][1]. On detection
of a mix of positive and negative deltas, it will convert them all to
milliseconds and bubble that up.

Moment 2.10.3:

    moment.duration({days: -1, hours: 1}).days()
    -1
    moment.duration({days: -1, hours: 1}).hours()
    1

Moment 2.10.6:

    moment.duration({days: -1, hours: 1}).days()
    0
    moment.duration({days: -1, hours: 1}).hours()
    -23

This commit makes FullCalendar's automated test for event dragging
expect the new results.

[1]: https://github.com/moment/moment/commit/950bfea60b5cf49edc57f61592b0ea6701feea07