### PR TITLE
Fix karma peerinvalid error during npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "grunt-karma": "^0.8.3",
     "grunt-bump": "0.0.14",
     "lumbar": "^2.6.2",
+    "karma": "~0.12.0",
     "karma-jasmine": "^0.2.2",
     "karma-phantomjs-launcher": "^0.1.4"
   },


### PR DESCRIPTION
Previously when running `npm install` on a fresh git clone, errors where thrown because the karma version could not be determined. By explicitly setting the karma version, `npm install` succeeds as expected.

Fixes #2901 