### PR TITLE
Ignore npm debug logs generated when npm install failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules
 
 # bower components
 lib/*/*
+
+# ignore NPM logs
+npm-debug.log


### PR DESCRIPTION
On current master (before merging #3010), `npm install` on a fresh git clone would fail and create a `npm-debug.log`. This log should not be committed to the main repository.