### PR TITLE
Use en dash for ranges

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,7 +1,7 @@
 
 Calendar.defaults = {
 
-	titleRangeSeparator: ' \u2014 ', // emphasized dash
+	titleRangeSeparator: ' \u2013 ', // en dash
 	monthYearFormat: 'MMMM YYYY', // required for en. other languages rely on datepicker computable option
 
 	defaultTimedEventDuration: '02:00:00',


### PR DESCRIPTION
This is just a tiny nitpick, but the long (em) dash in the title has bothered me for a while now. The recommended dash for time ranges is the (shorter) en dash (see e.g. http://www.fonts.com/content/learning/fyti/glyphs/hyphens-and-dashes), and I think it looks nicer, too. Of course users can override the value in configuration, but en dash is a more sensible default than em dash