### PR TITLE
prevent flicker when refetchEvents is called (fix #2558)

### DIFF
--- a/src/common/DayGrid.events.js
+++ b/src/common/DayGrid.events.js
@@ -58,10 +58,15 @@ DayGrid.mixin({
 	unrenderFgSegs: function() {
 		var rowStructs = this.rowStructs || [];
 		var rowStruct;
+		var _this = this;
 
-		while ((rowStruct = rowStructs.pop())) {
-			rowStruct.tbodyEl.remove();
-		}
+		this.el.on('segsRendered', function() {
+			while ((rowStruct = rowStructs.pop())) {
+				rowStruct.tbodyEl.remove();
+			}
+
+			_this.el.off('segsRendered');			
+		});
 
 		this.rowStructs = null;
 	},

--- a/src/common/Grid.events.js
+++ b/src/common/Grid.events.js
@@ -25,6 +25,8 @@ Grid.mixin({
 			this.renderBgEvents(bgEvents),
 			this.renderFgEvents(fgEvents)
 		);
+
+		this.el.trigger('segsRendered');
 	},
 
 

--- a/src/common/Grid.js
+++ b/src/common/Grid.js
@@ -453,9 +453,14 @@ var Grid = FC.Grid = Class.extend({
 	// Unrenders a specific type of fill that is currently rendered on the grid
 	unrenderFill: function(type) {
 		var el = this.elsByFill[type];
+		var _this = this;
 
 		if (el) {
-			el.remove();
+			this.el.on('segsRendered', function() {
+				el.remove();
+				
+				_this.el.off('segsRendered');
+			});
 			delete this.elsByFill[type];
 		}
 	},

--- a/src/common/TimeGrid.events.js
+++ b/src/common/TimeGrid.events.js
@@ -205,11 +205,16 @@ TimeGrid.mixin({
 	unrenderNamedSegs: function(propName) {
 		var segs = this[propName];
 		var i;
+		var _this = this;
 
 		if (segs) {
-			for (i = 0; i < segs.length; i++) {
-				segs[i].el.remove();
-			}
+			this.el.on('segsRendered', function(e) {
+				for (i = 0; i < segs.length; i++) {
+					segs[i].el.remove();
+				}
+				_this.el.off('segsRendered');
+			});
+
 			this[propName] = null;
 		}
 	},


### PR DESCRIPTION
This fixes issue #2558. Adds a 'segsRendered' event listener, to prevent the old segs from being unrendered until the new ones are rendered.

Using the "refetchResources" button, see existing behavior here: http://plnkr.co/edit/mVKWwskWG1qiETSeIecl?p=preview

See new behavior here: http://plnkr.co/edit/HWcu73G41fh5BlnZpDFE?p=preview