### PR TITLE
Upgrade to jQuery Mockjax 2.1.1 (fixes some automated tests)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "jquery-ui": ">=1.11.1",
     "jquery-simulate": "~1.0.1",
-    "jquery-mockjax": "~1.5.4",
+    "jquery-mockjax": "~2.1.1",
     "jasmine-jquery": "~2.0.3",
     "jasmine-fixture": "~1.2.0",
     "moment-timezone": "~0.2.1",

--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function(config) {
 			'../lib/jquery-ui/jquery-ui.js',
 
 			'../lib/jquery-simulate/jquery.simulate.js',
-			'../lib/jquery-mockjax/jquery.mockjax.js',
+			'../lib/jquery-mockjax/dist/jquery.mockjax.js',
 			'../lib/jasmine-jquery/lib/jasmine-jquery.js',
 			'../lib/jasmine-fixture/dist/jasmine-fixture.js',
 

--- a/tests/automated/event-feed-param.js
+++ b/tests/automated/event-feed-param.js
@@ -24,7 +24,7 @@ describe('event feed params', function() {
 	});
 
 	afterEach(function() {
-		$.mockjaxClear();
+		$.mockjax.clear();
 	});
 
 	it('utilizes custom startParam, endParam, and timezoneParam names', function() {

--- a/tests/automated/events-gcal.js
+++ b/tests/automated/events-gcal.js
@@ -41,7 +41,7 @@ xdescribe('Google Calendar plugin', function() {
 	});
 
 	afterEach(function() {
-		$.mockjaxClear();
+		$.mockjax.clear();
 		$.mockjaxSettings.log = function() { };
 		console.warn = oldConsoleWarn;
 	});

--- a/tests/automated/events-json-feed.js
+++ b/tests/automated/events-json-feed.js
@@ -25,7 +25,7 @@ describe('events as a json feed', function() {
 	});
 
 	afterEach(function() {
-		$.mockjaxClear();
+		$.mockjax.clear();
 	});
 
 	it('requests correctly when no timezone', function() {

--- a/tests/automated/removeEventSource.js
+++ b/tests/automated/removeEventSource.js
@@ -15,7 +15,7 @@ describe('removeEventSource', function() {
 	});
 
 	afterEach(function() {
-		$.mockjaxClear();
+		$.mockjax.clear();
 	});
 
 	describe('with a URL', function() {


### PR DESCRIPTION
Some tests of `tests/automated/events-json-feed.js` and `tests/automated/removeEventSource.js` fail when using jQuery Mockjax 1.5.4 together with jQuery 2.2.x.

```
PhantomJS 1.9.8 (Linux 0.0.0) events as a json feed requests correctly with event source extended form FAILED
	Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.
PhantomJS 1.9.8 (Linux 0.0.0) removeEventSource with a URL correctly removes events provided via `events` at initialization FAILED
	Expected 0 to be 2.
PhantomJS 1.9.8 (Linux 0.0.0) removeEventSource with a URL correctly removes events provided via `eventSources` at initialization FAILED
	Expected 0 to be 2.
PhantomJS 1.9.8 (Linux 0.0.0) removeEventSource with a URL correctly removes events provided via `addEventSource` method FAILED
	Expected 0 to be 2.
PhantomJS 1.9.8 (Linux 0.0.0) removeEventSource with an object+url correctly removes events provided via `events` at initialization FAILED
	Expected 0 to be 2.
PhantomJS 1.9.8 (Linux 0.0.0) removeEventSource with an object+url correctly removes events provided via `eventSources` at initialization FAILED
	Expected 0 to be 2.
PhantomJS 1.9.8 (Linux 0.0.0) removeEventSource with an object+url correctly removes events provided via `addEventSource` method FAILED
	Expected 0 to be 2.
```

A fix was provided in jakerella/jquery-mockjax#275 (also works when applied manually to Mockjax 1.5.4) and was merged into Mockjax 2.1.0. I propose to upgrade the Mockjax version used in FullCalendar's automated tests to Mockjax 2.1.1.

Note that Mockjax 2.1.1 itself has a dependency on `"jquery": "~2.1.3"`, which disallows jQuery 2.2, but this has already been fixed in their development master (https://github.com/jakerella/jquery-mockjax/issues/281).

Either way, with this PR all automated tests for FullCalendar succeed again (Mockjax 2.1.1, jQuery 2.1.3/2.2.2).