### PR TITLE
add getEventSources and refetchEventSources methods to refetch specific event sources

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -707,11 +707,13 @@ function Calendar_constructor(element, overrides) {
 
 
 	function refetchEventSources(specificSources, shouldClearAll) {
-		// if specificSources isn't an array (i.e. one event source), add it to an array
-		if (specificSources && !$.isArray(specificSources)) {
-			specificSources = [ specificSources ];
+		if (specificSources) {
+			// if specificSources isn't an array (i.e. one event source), add it to an array
+			if (!$.isArray(specificSources)) {
+				specificSources = [ specificSources ];
+			}
+			fetchEventSources(specificSources, shouldClearAll);
 		}
-		fetchEventSources(specificSources, shouldClearAll);
 	}
 
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -706,6 +706,7 @@ function Calendar_constructor(element, overrides) {
 
 
 	function refetchEventSources(eventSources) {
+		// if eventSources isn't an array (i.e. one event source), add it to an array
 		if (eventSources && !$.isArray(eventSources)) {
 			eventSources = [ eventSources ];
 		}

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -461,6 +461,7 @@ function Calendar_constructor(element, overrides) {
 	EventManager.call(t, options);
 	var isFetchNeeded = t.isFetchNeeded;
 	var fetchEvents = t.fetchEvents;
+	var fetchEventSources = t.fetchEventSources;
 
 
 
@@ -705,12 +706,12 @@ function Calendar_constructor(element, overrides) {
 	}
 
 
-	function refetchEventSources(eventSources) {
+	function refetchEventSources(eventSources, shouldClearAll) {
 		// if eventSources isn't an array (i.e. one event source), add it to an array
 		if (eventSources && !$.isArray(eventSources)) {
 			eventSources = [ eventSources ];
 		}
-		fetchAndRenderEvents(eventSources);
+		fetchEventSources(eventSources, shouldClearAll);
 	}
 
 
@@ -740,8 +741,8 @@ function Calendar_constructor(element, overrides) {
 	}
 
 
-	function fetchAndRenderEvents(eventSources) {
-		fetchEvents(currentView.start, currentView.end, eventSources);
+	function fetchAndRenderEvents() {
+		fetchEvents(currentView.start, currentView.end);
 			// ... will call reportEvents
 			// ... which will call renderEvents
 	}

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -270,6 +270,7 @@ function Calendar_constructor(element, overrides) {
 	t.render = render;
 	t.destroy = destroy;
 	t.refetchEvents = refetchEvents;
+	t.refetchEventSources = refetchEventSources;
 	t.reportEvents = reportEvents;
 	t.reportEventChange = reportEventChange;
 	t.rerenderEvents = renderEvents; // `renderEvents` serves as a rerender. an API method
@@ -704,6 +705,14 @@ function Calendar_constructor(element, overrides) {
 	}
 
 
+	function refetchEventSources(eventSources) {
+		if (eventSources && !$.isArray(eventSources)) {
+			eventSources = [ eventSources ];
+		}
+		fetchAndRenderEvents(eventSources);
+	}
+
+
 	function renderEvents() { // destroys old events if previously rendered
 		if (elementVisible()) {
 			freezeContentHeight();
@@ -730,8 +739,8 @@ function Calendar_constructor(element, overrides) {
 	}
 
 
-	function fetchAndRenderEvents() {
-		fetchEvents(currentView.start, currentView.end);
+	function fetchAndRenderEvents(eventSources) {
+		fetchEvents(currentView.start, currentView.end, eventSources);
 			// ... will call reportEvents
 			// ... which will call renderEvents
 	}

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -706,12 +706,12 @@ function Calendar_constructor(element, overrides) {
 	}
 
 
-	function refetchEventSources(eventSources, shouldClearAll) {
-		// if eventSources isn't an array (i.e. one event source), add it to an array
-		if (eventSources && !$.isArray(eventSources)) {
-			eventSources = [ eventSources ];
+	function refetchEventSources(specificSources, shouldClearAll) {
+		// if specificSources isn't an array (i.e. one event source), add it to an array
+		if (specificSources && !$.isArray(specificSources)) {
+			specificSources = [ specificSources ];
 		}
-		fetchEventSources(eventSources, shouldClearAll);
+		fetchEventSources(specificSources, shouldClearAll);
 	}
 
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -706,13 +706,13 @@ function Calendar_constructor(element, overrides) {
 	}
 
 
-	function refetchEventSources(specificSources, shouldClearAll) {
+	function refetchEventSources(specificSources) {
 		if (specificSources) {
 			// if specificSources isn't an array (i.e. one event source), add it to an array
 			if (!$.isArray(specificSources)) {
 				specificSources = [ specificSources ];
 			}
-			fetchEventSources(specificSources, shouldClearAll);
+			fetchEventSources(specificSources);
 		}
 	}
 

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -64,15 +64,25 @@ function EventManager(options) { // assumed to be a calendar
 	}
 	
 	
-	function fetchEvents(start, end) {
+	function fetchEvents(start, end, eventSources) {
 		rangeStart = start;
 		rangeEnd = end;
-		cache = [];
+		cache = eventSources ? cache : [];
 		var fetchID = ++currentFetchID;
-		var len = sources.length;
+		var len = eventSources ? eventSources.length : sources.length;
 		pendingSourceCnt = len;
+		function checkSources(e) {
+			return !isSourcesEqual(e.source, source);
+		}
 		for (var i=0; i<len; i++) {
-			fetchEventSource(sources[i], fetchID);
+			var source = eventSources ? eventSources[i] : sources[i];
+
+			if (eventSources) {
+        		// remove events from the cache that are part of the source being refetched
+        		cache = $.grep(cache, checkSources);
+    		}
+
+			fetchEventSource(source, fetchID);
 		}
 	}
 	

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -18,6 +18,7 @@ function EventManager(options) { // assumed to be a calendar
 	t.isFetchNeeded = isFetchNeeded;
 	t.fetchEvents = fetchEvents;
 	t.fetchEventSources = fetchEventSources;
+	t.getEventSources = getEventSources;
 	t.addEventSource = addEventSource;
 	t.removeEventSource = removeEventSource;
 	t.updateEvent = updateEvent;
@@ -242,7 +243,12 @@ function EventManager(options) { // assumed to be a calendar
 	
 	/* Sources
 	-----------------------------------------------------------------------------*/
-	
+
+
+	function getEventSources() {
+		return sources.slice(1); // returns a shallow copy of sources with stickySource removed
+	}
+
 
 	function addEventSource(sourceInput) {
 		var source = buildEventSource(sourceInput);

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -78,22 +78,22 @@ function EventManager(options) { // assumed to be a calendar
 	}
 
 
-	function fetchEventSources(eventSources, shouldClearAll) {
+	function fetchEventSources(specificSources, shouldClearAll) {
 		if (shouldClearAll) {
 			cache = [];
 		}
 		var fetchID = ++currentFetchID;
-		var len = eventSources.length;
+		var len = specificSources.length;
 		pendingSourceCnt += len;
 		function checkSources(e) {
-			return !isSourcesEqual(e.source, eventSources[i]);
+			return !isSourcesEqual(e.source, specificSources[i]);
 		}
 		for (var i=0; i<len; i++) {
 			if (!shouldClearAll) {
         		// remove events from the cache that belong to the source being refetched
         		cache = $.grep(cache, checkSources);
         	}
-        	fetchEventSource(eventSources[i], fetchID);
+        	fetchEventSource(specificSources[i], fetchID);
         }
 	}
 

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -17,6 +17,7 @@ function EventManager(options) { // assumed to be a calendar
 	// exports
 	t.isFetchNeeded = isFetchNeeded;
 	t.fetchEvents = fetchEvents;
+	t.fetchEventSources = fetchEventSources;
 	t.addEventSource = addEventSource;
 	t.removeEventSource = removeEventSource;
 	t.updateEvent = updateEvent;
@@ -64,29 +65,39 @@ function EventManager(options) { // assumed to be a calendar
 	}
 	
 	
-	function fetchEvents(start, end, eventSources) {
+	function fetchEvents(start, end) {
 		rangeStart = start;
 		rangeEnd = end;
-		cache = eventSources ? cache : [];
+		cache = [];
 		var fetchID = ++currentFetchID;
-		var len = eventSources ? eventSources.length : sources.length;
+		var len = sources.length;
 		pendingSourceCnt = len;
-		function checkSources(e) {
-			return !isSourcesEqual(e.source, source);
-		}
 		for (var i=0; i<len; i++) {
-			var source = eventSources ? eventSources[i] : sources[i];
-
-			if (eventSources) {
-        		// remove events from the cache that are part of the source being refetched
-        		cache = $.grep(cache, checkSources);
-    		}
-
-			fetchEventSource(source, fetchID);
+			fetchEventSource(sources[i], fetchID);
 		}
 	}
-	
-	
+
+
+	function fetchEventSources(eventSources, shouldClearAll) {
+		if (shouldClearAll) {
+			cache = [];
+		}
+		var fetchID = ++currentFetchID;
+		var len = eventSources.length;
+		pendingSourceCnt += len;
+		function checkSources(e) {
+			return !isSourcesEqual(e.source, eventSources[i]);
+		}
+		for (var i=0; i<len; i++) {
+			if (!shouldClearAll) {
+        		// remove events from the cache that belong to the source being refetched
+        		cache = $.grep(cache, checkSources);
+        	}
+        	fetchEventSource(eventSources[i], fetchID);
+        }
+	}
+
+
 	function fetchEventSource(source, fetchID) {
 		_fetchEventSource(source, function(eventInputs) {
 			var isArraySource = $.isArray(source.events);

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -84,11 +84,11 @@ function EventManager(options) { // assumed to be a calendar
 		}
 		for (var i=0; i<len; i++) {
 			if (!shouldClearAll) {
-        		// remove events from the cache that belong to the source being refetched
-        		cache = $.grep(cache, checkSources);
-        	}
-        	fetchEventSource(specificSources[i], fetchID);
-        }
+				// remove events from the cache that belong to the source being refetched
+				cache = $.grep(cache, checkSources);
+			}
+			fetchEventSource(specificSources[i], fetchID);
+		}
 	}
 
 

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -68,13 +68,7 @@ function EventManager(options) { // assumed to be a calendar
 	function fetchEvents(start, end) {
 		rangeStart = start;
 		rangeEnd = end;
-		cache = [];
-		var fetchID = ++currentFetchID;
-		var len = sources.length;
-		pendingSourceCnt = len;
-		for (var i=0; i<len; i++) {
-			fetchEventSource(sources[i], fetchID);
-		}
+		fetchEventSources(sources, true);
 	}
 
 

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -80,7 +80,7 @@ function EventManager(options) { // assumed to be a calendar
 		var len = specificSources.length;
 		pendingSourceCnt += len;
 		function checkSources(e) {
-			return !isSourcesEqual(e.source, specificSources[i]);
+			return e.source !== specificSources[i];
 		}
 		for (var i=0; i<len; i++) {
 			if (!shouldClearAll) {

--- a/tests/automated/getEventSources.js
+++ b/tests/automated/getEventSources.js
@@ -1,0 +1,44 @@
+describe('getEventSources', function() {
+	var options;
+	var calendarEl;
+
+	beforeEach(function() {
+		affix('#cal');
+		calendarEl = $('#cal');
+		options = {
+			now: '2015-08-07',
+			defaultView: 'agendaWeek',
+			eventSources: [
+				{
+					events: [
+						{ id: 1, start: '2015-08-07T02:00:00', end: '2015-08-07T03:00:00', title: 'event A' }
+					]
+				},
+				{
+					events: [
+						{ id: 2, start: '2015-08-07T03:00:00', end: '2015-08-07T04:00:00', title: 'event B' }
+					]
+				},
+				{
+					events: [
+						{ id: 3, start: '2015-08-07T04:00:00', end: '2015-08-07T05:00:00', title: 'event C' }
+					]
+				}
+			]
+		};
+	});
+
+	it('does not mutate when removeEventSource is called', function(done) {
+		var eventSources;
+
+		calendarEl.fullCalendar(options);
+
+		eventSources = calendarEl.fullCalendar('getEventSources');
+		expect(eventSources.length).toBe(3);
+
+		calendarEl.fullCalendar('removeEventSource', eventSources[0]);
+		expect(eventSources.length).toBe(3);
+
+		done();
+	});
+});

--- a/tests/automated/refetchEventSources.js
+++ b/tests/automated/refetchEventSources.js
@@ -53,7 +53,7 @@ describe('refetchEventSources', function() {
 			expect($('.source2').length).toEqual(2);
 			expect($('.source3').length).toEqual(1);
 
-			done();			
+			done();
 		});
 	});
 
@@ -79,7 +79,7 @@ describe('refetchEventSources', function() {
 			expect($('.source2').length).toEqual(1);
 			expect($('.source3').length).toEqual(2);
 
-			done();			
+			done();
 		});
 	});
 

--- a/tests/automated/refetchEventSources.js
+++ b/tests/automated/refetchEventSources.js
@@ -1,0 +1,103 @@
+describe('refetchEventSources', function() {
+	var calendarEl;
+	var eventCount;
+	var options;
+
+	beforeEach(function() {
+		affix('#cal');
+		calendarEl = $('#cal');
+		eventCount = 1;
+		options = {
+			now: '2015-08-07',
+			defaultView: 'agendaWeek',
+			eventSources: [
+				{
+					events: createEventGenerator('source1', 'A'),
+					color: 'green',
+					id: 'source1'
+				},
+				{
+					events: createEventGenerator('source2', 'B'),
+					color: 'blue',
+					id: 'source2'
+				},
+				{
+					events: createEventGenerator('source3', 'C'),
+					color: 'green',
+					rendering: 'background',
+					id: 'source3'
+				}
+			]
+		};
+	});
+
+	describe('with a single event source passed in', function() {
+		it('only refetches events for the specified event source', function(done) {
+			calendarEl.fullCalendar(options);
+
+			expect($('.source1').length).toEqual(1);
+			expect($('.source2').length).toEqual(1);
+			expect($('.source3').length).toEqual(1);
+
+			var eventSources = $.grep(calendarEl.fullCalendar('getEventSources'), function(eventSource) {
+				return eventSource.color === 'blue';
+			});
+
+			// increase the number of events for the refetched source
+			eventCount = 2;
+
+			calendarEl.fullCalendar('refetchEventSources', eventSources[0]);
+
+			// ensure events have been updated
+			expect($('.source1').length).toEqual(1);
+			expect($('.source2').length).toEqual(2);
+			expect($('.source3').length).toEqual(1);
+
+			done();			
+		});
+	});
+
+	describe('with an array of multiple event sources passed in', function() {
+		it('only refetches events for the specified event sources', function(done) {
+			calendarEl.fullCalendar(options);
+
+			expect($('.source1').length).toEqual(1);
+			expect($('.source2').length).toEqual(1);
+			expect($('.source3').length).toEqual(1);
+
+			var eventSources = $.grep(calendarEl.fullCalendar('getEventSources'), function(eventSource) {
+				return eventSource.color === 'green';
+			});
+
+			// increase the number of events for the refetched sources
+			eventCount = 2;
+
+			calendarEl.fullCalendar('refetchEventSources', eventSources);
+
+			// ensure events have been updated
+			expect($('.source1').length).toEqual(2);
+			expect($('.source2').length).toEqual(1);
+			expect($('.source3').length).toEqual(2);
+
+			done();			
+		});
+	});
+
+	function createEventGenerator(sourceId, eventId) {
+		return function(start, end, timezone, callback) {
+			var events = [];
+
+			for (var i = 0; i < eventCount; i++) {
+				events.push({
+					id: eventId + i,
+					start: '2015-08-07T02:00:00',
+					end: '2015-08-07T03:00:00',
+					title: 'event ' + eventId,
+					className: sourceId
+				});
+			}
+
+			callback(events);
+		};
+	}
+});


### PR DESCRIPTION
close #254
close #1328

Example here: http://embed.plnkr.co/6s2LGElJC7Fyy004cmUC/.

This example also includes getEventSources for the purpose of retrieving the event sources. In the example, when refetchEventSources is called, an array of refetched eventSource IDs are displayed below the calendar.