### PR TITLE
prevent flicker when refetchEvents is called (fix #2558)

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -699,7 +699,6 @@ function Calendar_constructor(element, overrides) {
 
 
 	function refetchEvents() { // can be called as an API method
-		destroyEvents(); // so that events are cleared before user starts waiting for AJAX
 		fetchAndRenderEvents();
 	}
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -710,13 +710,6 @@ function Calendar_constructor(element, overrides) {
 			unfreezeContentHeight();
 		}
 	}
-
-
-	function destroyEvents() {
-		freezeContentHeight();
-		currentView.clearEvents();
-		unfreezeContentHeight();
-	}
 	
 
 	function getAndRenderEvents() {

--- a/tests/automated/refetchEvents.js
+++ b/tests/automated/refetchEvents.js
@@ -1,4 +1,4 @@
-ddescribe('refetchEvents', function() {
+describe('refetchEvents', function() {
 	describe('when agenda events are rerendered', function() {
 		beforeEach(function() {
 			affix('#cal');

--- a/tests/automated/refetchEvents.js
+++ b/tests/automated/refetchEvents.js
@@ -50,6 +50,7 @@ ddescribe('refetchEvents', function() {
 
 		beforeEach(function() {
 			affix('#cal');
+			fetchCount = 0;
 			currentCalendar = $('#cal');
 			options = {
 				now: '2015-08-07',
@@ -76,7 +77,6 @@ ddescribe('refetchEvents', function() {
 
 		describe('and all events are fetched synchronously', function() {
 			it('all events are immediately updated', function(done) {
-				fetchCount = 0;
 				currentCalendar.fullCalendar(options);
 				fetchCount++;
 				currentCalendar.fullCalendar('refetchEvents');
@@ -87,7 +87,6 @@ ddescribe('refetchEvents', function() {
 
 		describe('and one event source is asynchronous', function() {
 			it('original events remain on the calendar until all events have been refetched', function(done) {
-				fetchCount = 0;
 				// set a 100ms timeout on this event source
 				options.eventSources[0].events = function(start, end, timezone, callback) {
 					var events = [

--- a/tests/automated/refetchEvents.js
+++ b/tests/automated/refetchEvents.js
@@ -46,12 +46,12 @@ ddescribe('refetchEvents', function() {
 	describe('when there are multiple event sources', function() {
 		var options;
 		var fetchCount;
-		var currentCalendar;
+		var calendarEl;
 
 		beforeEach(function() {
 			affix('#cal');
 			fetchCount = 0;
-			currentCalendar = $('#cal');
+			calendarEl = $('#cal');
 			options = {
 				now: '2015-08-07',
 				defaultView: 'agendaWeek',
@@ -77,9 +77,9 @@ ddescribe('refetchEvents', function() {
 
 		describe('and all events are fetched synchronously', function() {
 			it('all events are immediately updated', function(done) {
-				currentCalendar.fullCalendar(options);
+				calendarEl.fullCalendar(options);
 				fetchCount++;
-				currentCalendar.fullCalendar('refetchEvents');
+				calendarEl.fullCalendar('refetchEvents');
 				checkAllEvents();
 				done();
 			});
@@ -101,7 +101,7 @@ ddescribe('refetchEvents', function() {
 					fetchCount++;
 					if (fetchCount === 1) {
 						// after the initial rendering of events, call refetchEvents
-						currentCalendar.fullCalendar('refetchEvents');
+						calendarEl.fullCalendar('refetchEvents');
 
 						expect($('.fetch0').length).toEqual(3); // original events still on the calendar
 						expect($('.fetch1').length).toEqual(0); // new events not yet refetched
@@ -113,7 +113,7 @@ ddescribe('refetchEvents', function() {
 					}
 				};
 
-				currentCalendar.fullCalendar(options);
+				calendarEl.fullCalendar(options);
 			});
 		});
 

--- a/tests/automated/refetchEvents.js
+++ b/tests/automated/refetchEvents.js
@@ -42,4 +42,94 @@ describe('refetchEvents', function() {
 			});
 		});
 	});
+
+	describe('when there are multiple event sources', function() {
+		var options;
+		var count;
+		var currentCalendar;
+
+		beforeEach(function() {
+			affix('#cal');
+			currentCalendar = $('#cal');
+			options = {
+				now: '2015-08-07',
+				defaultView: 'agendaWeek',
+				eventSources: [
+					{
+						events: createEvents(1),
+						color: 'green',
+						id: 'source1'
+					},
+					{
+						events: createEvents(2),
+						color: 'blue',
+						id: 'source2'
+					},
+					{
+						events: createEvents(3),
+						color: 'red',
+						id: 'source3'
+					}
+				]
+			};
+		});
+
+		describe('and all events are fetched synchronously', function() {
+			it('all events are immediately updated', function(done) {
+				count = 0;
+				currentCalendar.fullCalendar(options);
+				count++;
+				currentCalendar.fullCalendar('refetchEvents');
+				checkAllEvents();
+				done();
+			});
+		});
+
+		describe('and one event source is asynchronous', function() {
+			it('original events remain on the calendar until all events have been refetched', function(done) {
+				count = 0;
+				options.eventSources[0].events = createEvents(1, 100); // set a 100ms timeout on this event source
+				options.eventAfterAllRender = function() {
+					count++;
+					if (count === 1) {
+						// after the initial rendering of events, call refetchEvents
+						currentCalendar.fullCalendar('refetchEvents');
+
+						expect($('.fetch0').length).toEqual(3); // original events still on the calendar
+						expect($('.fetch1').length).toEqual(0); // new events not yet refetched
+
+						setTimeout(function() {
+							checkAllEvents();
+							done();
+						}, 100);
+					}
+				};
+
+				currentCalendar.fullCalendar(options);
+			});
+		});
+
+		function createEvents(id, delay) {
+			return function(start, end, timezone, callback) {
+				var events = [
+					{ id: 1, start: '2015-08-07T02:00:00', end: '2015-08-07T03:00:00', title: 'event A', className: 'fetch' + count }
+				];
+
+				if (delay) {
+					setTimeout(function() {
+						callback(events);
+					}, delay);
+				}
+				else {
+					callback(events);
+				}
+			};
+		}
+
+		// Checks to make sure all refetched events have been rendered
+		function checkAllEvents() {
+			expect($('.fetch0').length).toEqual(0);
+			expect($('.fetch1').length).toEqual(3);
+		}
+	});
 });

--- a/tests/automated/refetchEvents.js
+++ b/tests/automated/refetchEvents.js
@@ -1,45 +1,45 @@
+describe('refetchEvents', function() {
+	describe('when agenda events are rerendered', function() {
+		beforeEach(function() {
+			affix('#cal');
+		});
 
-describe('when agenda events are rerendered', function() {
-	beforeEach(function() {
-		affix('#cal');
-	});
+		it('keeps scroll after refetchEvents', function(done) {
+			var renderCalls = 0;
 
-	it('keeps scroll after refetchEvents', function(done) {
-		var renderCalls = 0;
-
-		$('#cal').fullCalendar({
-			now: '2015-08-07',
-			scrollTime: '00:00',
-			height: 400, // makes this test more consistent across viewports
-			defaultView: 'agendaDay',
-			events: function(start, end, timezone, callback) {
-				setTimeout(function() {
-					callback([
-						{ id: '1', resourceId: 'b', start: '2015-08-07T02:00:00', end: '2015-08-07T07:00:00', title: 'event 1' },
-						{ id: '2', resourceId: 'c', start: '2015-08-07T05:00:00', end: '2015-08-07T22:00:00', title: 'event 2' },
-						{ id: '3', resourceId: 'd', start: '2015-08-06', end: '2015-08-08', title: 'event 3' },
-						{ id: '4', resourceId: 'e', start: '2015-08-07T03:00:00', end: '2015-08-07T08:00:00', title: 'event 4' },
-						{ id: '5', resourceId: 'f', start: '2015-08-07T00:30:00', end: '2015-08-07T02:30:00', title: 'event 5' }
-					]);
-				}, 100);
-			},
-			eventAfterAllRender: function() {
-				var scrollEl = $('.fc-time-grid-container.fc-scroller');
-				renderCalls++;
-				if (renderCalls == 1) {
+			$('#cal').fullCalendar({
+				now: '2015-08-07',
+				scrollTime: '00:00',
+				height: 400, // makes this test more consistent across viewports
+				defaultView: 'agendaDay',
+				events: function(start, end, timezone, callback) {
 					setTimeout(function() {
-						scrollEl.scrollTop(100);
-						setTimeout(function() {
-							$('#cal').fullCalendar('refetchEvents');
-						}, 100);
+						callback([
+							{ id: '1', resourceId: 'b', start: '2015-08-07T02:00:00', end: '2015-08-07T07:00:00', title: 'event 1' },
+							{ id: '2', resourceId: 'c', start: '2015-08-07T05:00:00', end: '2015-08-07T22:00:00', title: 'event 2' },
+							{ id: '3', resourceId: 'd', start: '2015-08-06', end: '2015-08-08', title: 'event 3' },
+							{ id: '4', resourceId: 'e', start: '2015-08-07T03:00:00', end: '2015-08-07T08:00:00', title: 'event 4' },
+							{ id: '5', resourceId: 'f', start: '2015-08-07T00:30:00', end: '2015-08-07T02:30:00', title: 'event 5' }
+						]);
 					}, 100);
+				},
+				eventAfterAllRender: function() {
+					var scrollEl = $('.fc-time-grid-container.fc-scroller');
+					renderCalls++;
+					if (renderCalls == 1) {
+						setTimeout(function() {
+							scrollEl.scrollTop(100);
+							setTimeout(function() {
+								$('#cal').fullCalendar('refetchEvents');
+							}, 100);
+						}, 100);
+					}
+					else if (renderCalls == 2) {
+						expect(scrollEl.scrollTop()).toBe(100);
+						done();
+					}
 				}
-				else if (renderCalls == 2) {
-					expect(scrollEl.scrollTop()).toBe(100);
-					done();
-				}
-			}
+			});
 		});
 	});
-
 });

--- a/tests/automated/refetchEvents.js
+++ b/tests/automated/refetchEvents.js
@@ -1,4 +1,4 @@
-describe('refetchEvents', function() {
+ddescribe('refetchEvents', function() {
 	describe('when agenda events are rerendered', function() {
 		beforeEach(function() {
 			affix('#cal');
@@ -56,17 +56,17 @@ describe('refetchEvents', function() {
 				defaultView: 'agendaWeek',
 				eventSources: [
 					{
-						events: createEvents(1),
+						events: createEvents(),
 						color: 'green',
 						id: 'source1'
 					},
 					{
-						events: createEvents(2),
+						events: createEvents(),
 						color: 'blue',
 						id: 'source2'
 					},
 					{
-						events: createEvents(3),
+						events: createEvents(),
 						color: 'red',
 						id: 'source3'
 					}
@@ -88,7 +88,16 @@ describe('refetchEvents', function() {
 		describe('and one event source is asynchronous', function() {
 			it('original events remain on the calendar until all events have been refetched', function(done) {
 				count = 0;
-				options.eventSources[0].events = createEvents(1, 100); // set a 100ms timeout on this event source
+				// set a 100ms timeout on this event source
+				options.eventSources[0].events = function(start, end, timezone, callback) {
+					var events = [
+						{ id: '1', start: '2015-08-07T02:00:00', end: '2015-08-07T03:00:00', title: 'event A', className: 'fetch' + count }
+					];
+
+					setTimeout(function() {
+						callback(events);
+					}, 100);
+				};
 				options.eventAfterAllRender = function() {
 					count++;
 					if (count === 1) {
@@ -109,20 +118,13 @@ describe('refetchEvents', function() {
 			});
 		});
 
-		function createEvents(id, delay) {
+		function createEvents() {
 			return function(start, end, timezone, callback) {
 				var events = [
 					{ id: 1, start: '2015-08-07T02:00:00', end: '2015-08-07T03:00:00', title: 'event A', className: 'fetch' + count }
 				];
 
-				if (delay) {
-					setTimeout(function() {
-						callback(events);
-					}, delay);
-				}
-				else {
-					callback(events);
-				}
+				callback(events);
 			};
 		}
 

--- a/tests/automated/refetchEvents.js
+++ b/tests/automated/refetchEvents.js
@@ -45,7 +45,7 @@ ddescribe('refetchEvents', function() {
 
 	describe('when there are multiple event sources', function() {
 		var options;
-		var count;
+		var fetchCount;
 		var currentCalendar;
 
 		beforeEach(function() {
@@ -56,17 +56,17 @@ ddescribe('refetchEvents', function() {
 				defaultView: 'agendaWeek',
 				eventSources: [
 					{
-						events: createEvents(),
+						events: createEventGenerator(),
 						color: 'green',
 						id: 'source1'
 					},
 					{
-						events: createEvents(),
+						events: createEventGenerator(),
 						color: 'blue',
 						id: 'source2'
 					},
 					{
-						events: createEvents(),
+						events: createEventGenerator(),
 						color: 'red',
 						id: 'source3'
 					}
@@ -76,9 +76,9 @@ ddescribe('refetchEvents', function() {
 
 		describe('and all events are fetched synchronously', function() {
 			it('all events are immediately updated', function(done) {
-				count = 0;
+				fetchCount = 0;
 				currentCalendar.fullCalendar(options);
-				count++;
+				fetchCount++;
 				currentCalendar.fullCalendar('refetchEvents');
 				checkAllEvents();
 				done();
@@ -87,11 +87,11 @@ ddescribe('refetchEvents', function() {
 
 		describe('and one event source is asynchronous', function() {
 			it('original events remain on the calendar until all events have been refetched', function(done) {
-				count = 0;
+				fetchCount = 0;
 				// set a 100ms timeout on this event source
 				options.eventSources[0].events = function(start, end, timezone, callback) {
 					var events = [
-						{ id: '1', start: '2015-08-07T02:00:00', end: '2015-08-07T03:00:00', title: 'event A', className: 'fetch' + count }
+						{ id: '1', start: '2015-08-07T02:00:00', end: '2015-08-07T03:00:00', title: 'event A', className: 'fetch' + fetchCount }
 					];
 
 					setTimeout(function() {
@@ -99,8 +99,8 @@ ddescribe('refetchEvents', function() {
 					}, 100);
 				};
 				options.eventAfterAllRender = function() {
-					count++;
-					if (count === 1) {
+					fetchCount++;
+					if (fetchCount === 1) {
 						// after the initial rendering of events, call refetchEvents
 						currentCalendar.fullCalendar('refetchEvents');
 
@@ -118,10 +118,10 @@ ddescribe('refetchEvents', function() {
 			});
 		});
 
-		function createEvents() {
+		function createEventGenerator() {
 			return function(start, end, timezone, callback) {
 				var events = [
-					{ id: 1, start: '2015-08-07T02:00:00', end: '2015-08-07T03:00:00', title: 'event A', className: 'fetch' + count }
+					{ id: 1, start: '2015-08-07T02:00:00', end: '2015-08-07T03:00:00', title: 'event A', className: 'fetch' + fetchCount }
 				];
 
 				callback(events);


### PR DESCRIPTION
This removes the call to the destroyEvents function in refetchEvents(), as discussed here:
- https://github.com/fullcalendar/fullcalendar/issues/2558#issuecomment-132574399
- https://github.com/fullcalendar/fullcalendar/issues/2558#issuecomment-132574410

As the destroyEvents function isn't being used anywhere else, this pull request also removes that.

According to the comment, it's there "so that events are cleared before user starts waiting for AJAX." But, that's not what we want. Having the events cleared before the AJAX call is what causes the flicker. This supersedes #3094.

Using the "refetchResources" button, see existing behavior here:
http://plnkr.co/edit/mVKWwskWG1qiETSeIecl?p=preview

See new behavior here:
http://plnkr.co/edit/c8hqZePSz8KFphI2boAS?p=preview