### PR TITLE
Update EventManager.js

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -671,7 +671,7 @@ function EventManager(options) { // assumed to be a calendar
 				return diffByUnit(date1, date0, largeUnit);
 			}
 			else if (newProps.allDay) {
-				return diffDay(date1, date0);
+				return diffDay(date1, (date0 !== null) ? date0 : date1));
 			}
 			else {
 				return diffDayTime(date1, date0);


### PR DESCRIPTION
allDay events that have the same start and end date get their end date set to null.
Calling updateEvent on an event will trigger diffDates to run.
$('#calendar').fullCalendar('updateEvent', event, true);
But since the end date is null it will throw a type error since clone can't be called on a null.
The end date will normally (in good use) only be set to null when the start and end date are the same, so the start date (which is always set) can be used here instead of the empty end date.