### PR TITLE
jQuery 3.0 compatibility for removeAttr

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -226,14 +226,14 @@ function Header(calendar, options) {
 	
 	function disableButton(buttonName) {
 		el.find('.fc-' + buttonName + '-button')
-			.attr('disabled', 'disabled')
+			.prop('disabled', true)
 			.addClass(tm + '-state-disabled');
 	}
 	
 	
 	function enableButton(buttonName) {
 		el.find('.fc-' + buttonName + '-button')
-			.removeAttr('disabled')
+			.prop('disabled', false)
 			.removeClass(tm + '-state-disabled');
 	}
 


### PR DESCRIPTION
`removeAttr` will no longer set props to false. [Source](https://jquery.com/upgrade-guide/3.0/#breaking-change-removeattr-no-longer-sets-properties-to-false).

Further, by using `.prop`, it opens up the ability of reducing duplicated logic in `disableButton` and `enableButton`.