### PR TITLE
added changeView callback function

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -582,8 +582,7 @@ function Calendar_constructor(element, overrides) {
 			freezeContentHeight(); // prevent a scroll jump when view element is removed
 			currentView.removeElement();
 			currentView = t.view = null;
-			if(typeof t.options.changeView == 'function')
-				t.options.changeView(viewType);
+			t.trigger('changeView', null, viewType, currentView.type);
 		}
 
 		// if viewType changed, or the view was never created, create a fresh view

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -582,6 +582,8 @@ function Calendar_constructor(element, overrides) {
 			freezeContentHeight(); // prevent a scroll jump when view element is removed
 			currentView.removeElement();
 			currentView = t.view = null;
+			if(typeof t.options.changeView == 'function')
+				t.options.changeView(viewType);
 		}
 
 		// if viewType changed, or the view was never created, create a fresh view


### PR DESCRIPTION
Added changeView callback function which will be called every time the user switches view.
The option provided will be like this

```
$('#calendar').fullCalendar({
    ...
    changeView: function (changedView) {
        // do anything with the view that will be changed
    }
    ...
});
```

feature request ticket: #3521