### PR TITLE
Added render events for Popover

### DIFF
--- a/src/common/DayGrid.limit.js
+++ b/src/common/DayGrid.limit.js
@@ -264,6 +264,7 @@ DayGrid.mixin({
 
 		this.segPopover = new Popover(options);
 		this.segPopover.show();
+		view.triggerEventRender(true);
 	},
 
 

--- a/src/common/View.js
+++ b/src/common/View.js
@@ -643,11 +643,15 @@ var View = FC.View = Class.extend(EmitterMixin, ListenerMixin, {
 
 
 	// Signals that all events have been rendered
-	triggerEventRender: function() {
+	triggerEventRender: function(inPopover) {
 		this.renderedEventSegEach(function(seg) {
 			this.trigger('eventAfterRender', seg.event, seg.event, seg.el);
 		});
-		this.trigger('eventAfterAllRender');
+		if(!inPopover) {
+			this.trigger('eventAfterAllRender');
+		} else {
+			this.trigger('eventAfterAllPopoverRender');
+		}
 	},
 
 


### PR DESCRIPTION
Call "eventAfterAllPopoverRender" when all events in a Popover are rendered.
Moreover call "eventAfterRender" for every events in Popover.
