### PR TITLE
height:'auto' always shows scrollbars in month view on FF

### DIFF
--- a/src/common/common.css
+++ b/src/common/common.css
@@ -359,6 +359,7 @@ hr.fc-divider {
 
 .fc-bg table {
 	height: 100%; /* strech bg to bottom edge */
+	box-sizing: border-box; /* fix scrollbar issue in firefox */
 }
 
 


### PR DESCRIPTION
Currently the scrollbar is always shown in Firefox with a basic calendar like:

```
$('#calendar').fullCalendar({
	height: 'auto'
});
```

This CSS change fixes the issue.