### PR TITLE
fixes MonthView.setGridHeight and eventLimit

### DIFF
--- a/src/basic/MonthView.js
+++ b/src/basic/MonthView.js
@@ -11,7 +11,7 @@ var MonthView = FC.MonthView = BasicView.extend({
 
 		// ensure 6 weeks
 		if (this.isFixedWeeks()) {
-			rowCnt = Math.ceil(range.end.diff(range.start, 'weeks', true)); // could be partial weeks due to hiddenDays
+			this.rowCnt = rowCnt = Math.ceil(range.end.diff(range.start, 'weeks', true)); // could be partial weeks due to hiddenDays
 			range.end.add(6 - rowCnt, 'weeks');
 		}
 

--- a/src/common/DayGrid.limit.js
+++ b/src/common/DayGrid.limit.js
@@ -125,7 +125,7 @@ DayGrid.mixin({
 				// determine *all* segments below `seg` that occupy the same columns
 				colSegsBelow = [];
 				totalSegsBelow = 0;
-				while (col <= seg.rightCol) {
+				while (col < seg.rightCol) {
 					segsBelow = this.getCellSegs(row, col, levelLimit);
 					colSegsBelow.push(segsBelow);
 					totalSegsBelow += segsBelow.length;


### PR DESCRIPTION
fix: setGridHeight with 'auto' height doesn't calculate height
correctly; eventLimit puts more link in wrong location

When loading events dynamically, setting an auto height and event limit would squash the number of events shown down to be one less than intended.