### PR TITLE
Remove underscore (unused)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,5 @@
 
 module.exports = function(grunt) {
-
-	var _ = require('underscore');
-
 	// Load required NPM tasks.
 	// You must first run `npm install` in the project's root directory to get these dependencies.
 	grunt.loadNpmTasks('grunt-contrib-concat');
@@ -17,7 +14,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-karma');
 	grunt.loadNpmTasks('grunt-bump');
 	grunt.loadNpmTasks('lumbar');
-	
+
 	// This will eventually get passed to grunt.initConfig()
 	// Initialize multitasks...
 	var config = {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "karma": "^0.13.22",
     "karma-jasmine": "^0.2.2",
     "karma-phantomjs-launcher": "^0.1.4",
-    "lumbar": "^2.6.2",
-    "underscore": "^1.4.4"
+    "lumbar": "^2.6.2"
   },
   "main": "dist/fullcalendar.js",
   "files": [


### PR DESCRIPTION
This drops the `underscore` dev dependency. It was being used in the Gruntfile at some point, but it seems like that's history now.