### PR TITLE
add getEventSources method

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -17,6 +17,7 @@ function EventManager(options) { // assumed to be a calendar
 	// exports
 	t.isFetchNeeded = isFetchNeeded;
 	t.fetchEvents = fetchEvents;
+	t.getEventSources = getEventSources;
 	t.addEventSource = addEventSource;
 	t.removeEventSource = removeEventSource;
 	t.updateEvent = updateEvent;
@@ -227,7 +228,12 @@ function EventManager(options) { // assumed to be a calendar
 	
 	/* Sources
 	-----------------------------------------------------------------------------*/
-	
+
+
+	function getEventSources() {
+		return sources.slice(1); // returns a shallow copy of sources with stickySource removed
+	}
+
 
 	function addEventSource(sourceInput) {
 		var source = buildEventSource(sourceInput);

--- a/tests/automated/getEventSources.js
+++ b/tests/automated/getEventSources.js
@@ -1,0 +1,43 @@
+describe('getEventSources', function() {
+	var options;
+
+	beforeEach(function() {
+		affix('#cal');
+		options = {
+			now: '2015-08-07',
+			defaultView: 'agendaWeek',
+			eventSources: [
+				{
+					events: [
+						{ id: 1, start: '2015-08-07T02:00:00', end: '2015-08-07T03:00:00', title: 'event A' }
+					]
+				},
+				{
+					events: [
+						{ id: 2, start: '2015-08-07T03:00:00', end: '2015-08-07T04:00:00', title: 'event B' }
+					]
+				},
+				{
+					events: [
+						{ id: 3, start: '2015-08-07T04:00:00', end: '2015-08-07T05:00:00', title: 'event C' }
+					]
+				}
+			]
+		};
+	});
+
+	it('does not mutate when removeEventSource is called', function(done) {
+		var currentCalendar = $('#cal');
+		var eventSources;
+
+		currentCalendar.fullCalendar(options);
+
+		eventSources = currentCalendar.fullCalendar('getEventSources');
+		expect(eventSources.length).toBe(3);
+
+		currentCalendar.fullCalendar('removeEventSource', eventSources[0]);
+		expect(eventSources.length).toBe(3);
+
+		done();
+	});
+});

--- a/tests/automated/getEventSources.js
+++ b/tests/automated/getEventSources.js
@@ -3,6 +3,7 @@ describe('getEventSources', function() {
 
 	beforeEach(function() {
 		affix('#cal');
+		calendarEl = $('#cal');
 		options = {
 			now: '2015-08-07',
 			defaultView: 'agendaWeek',
@@ -27,15 +28,14 @@ describe('getEventSources', function() {
 	});
 
 	it('does not mutate when removeEventSource is called', function(done) {
-		var currentCalendar = $('#cal');
 		var eventSources;
 
-		currentCalendar.fullCalendar(options);
+		calendarEl.fullCalendar(options);
 
-		eventSources = currentCalendar.fullCalendar('getEventSources');
+		eventSources = calendarEl.fullCalendar('getEventSources');
 		expect(eventSources.length).toBe(3);
 
-		currentCalendar.fullCalendar('removeEventSource', eventSources[0]);
+		calendarEl.fullCalendar('removeEventSource', eventSources[0]);
 		expect(eventSources.length).toBe(3);
 
 		done();

--- a/tests/automated/getEventSources.js
+++ b/tests/automated/getEventSources.js
@@ -1,5 +1,6 @@
 describe('getEventSources', function() {
 	var options;
+	var calendarEl;
 
 	beforeEach(function() {
 		affix('#cal');


### PR DESCRIPTION
This method retrieves all event sources as discussed in #2433.

See an example here: http://embed.plnkr.co/HFwUWbNIS5SbeQ1JnZUw/. Clicking the `getEventSources` button adds the event sources to the console.