### PR TITLE
Use Travis to run automated tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - 'node'
+  - 'stable'
+
+before_script:
+  - bower install

--- a/bower.json
+++ b/bower.json
@@ -29,8 +29,8 @@
   "devDependencies": {
     "jquery-ui": ">=1.11.1",
     "jquery-simulate": "~1.0.1",
-    "jasmine-jquery": "~2.0.3",
-    "jasmine-fixture": "~1.2.0",
+    "jasmine-jquery": "~2.1.1",
+    "jasmine-fixture": "~2.0.0",
     "moment-timezone": "~0.2.1",
     "bootstrap": "~3.2.0",
     "jquery-mockjax": "~2.1.1"

--- a/package.json
+++ b/package.json
@@ -36,13 +36,15 @@
     "grunt-contrib-cssmin": "^1.0.1",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-uglify": "^1.0.1",
-    "grunt-jscs": "^2.8.0",
-    "grunt-karma": "^0.12.2",
+    "grunt-jscs": "^3.0.0",
+    "grunt-karma": "^2.0.0",
     "grunt-shell": "^1.3.0",
+    "jasmine-core": "^2.4.1",
     "karma": "^0.13.22",
-    "karma-jasmine": "^0.2.2",
-    "karma-phantomjs-launcher": "^0.1.4",
-    "lumbar": "^2.6.2",
+    "karma-jasmine": "^1.0.2",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "lumbar": "^4.0.2",
+    "phantomjs-prebuilt": "^2.1.7",
     "underscore": "^1.4.4"
   },
   "main": "dist/fullcalendar.js",
@@ -54,5 +56,8 @@
     "LICENSE.*",
     "CHANGELOG.*",
     "CONTRIBUTING.*"
-  ]
+  ],
+  "scripts": {
+    "test" : "grunt dev && grunt karma:single"
+  }
 }

--- a/tests/automated/background-events.js
+++ b/tests/automated/background-events.js
@@ -369,7 +369,7 @@ describe('background events', function() {
 			options.defaultView = 'agendaWeek';
 		});
 
-		describe('when LTR', function(done) {
+		describe('when LTR', function() {
 			it('render correctly on one day', function(done) {
 				options.events = [ {
 					start: '2014-11-04T01:00:00',

--- a/tests/automated/displayEventEnd.js
+++ b/tests/automated/displayEventEnd.js
@@ -43,7 +43,7 @@ describe('displayEventEnd', function() {
 					});
 				});
 
-				describe('with a timed event with no end time', function(done) {
+				describe('with a timed event with no end time', function() {
 					beforeEach(function() {
 						options.events = [ {
 							title: 'timed event',
@@ -102,7 +102,7 @@ describe('displayEventEnd', function() {
 					});
 				});
 
-				describe('with a timed event with no end time', function(done) {
+				describe('with a timed event with no end time', function() {
 					beforeEach(function() {
 						options.events = [ {
 							title: 'timed event',
@@ -119,7 +119,7 @@ describe('displayEventEnd', function() {
 					});
 				});
 
-				describe('with a timed event given an invalid end time', function(done) {
+				describe('with a timed event given an invalid end time', function() {
 					beforeEach(function() {
 						options.events = [ {
 							title: 'timed event',

--- a/tests/automated/select-callback.js
+++ b/tests/automated/select-callback.js
@@ -138,7 +138,7 @@ describe('select callback', function() {
 						});
 					});
 				});
-				describe('when selecting timed slots', function(done) {
+				describe('when selecting timed slots', function() {
 					it('gets fired correctly when the user selects slots', function(done) {
 						options.select = function(start, end, jsEvent, view) {
 							expect(moment.isMoment(start)).toEqual(true);


### PR DESCRIPTION
This sets up the basic infrastructure for testing on Travis. Detected some issues with the `describe` callbacks when upgrading the deps, so I fixed those.

Currently **3 tests are failing**. As there is no publicly available test history, it's hard to tell if these are failing due to bumping `devDeps`, or if they were failing to begin with.

Benefits:
 
 * Test suite will run against PR's automatically, saving review time :confetti_ball: 
 * Can program the test suite to automatically test against jQuery 2.x and 3.x in the future using [environment variables](https://docs.travis-ci.com/user/environment-variables/#Defining-Multiple-Variables-per-Item)

First test run resut:

https://travis-ci.org/avindra/fullcalendar/builds/137090723