### PR TITLE
Set JQuery to maximum of 2.1.3 in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   },
   "copyright": "2016 Adam Shaw",
   "dependencies": {
-    "jquery": ">=1.7.1",
+    "jquery": ">=1.7.1 && <=2.1.3",
     "moment": ">=2.5.0"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   },
   "copyright": "2016 Adam Shaw",
   "dependencies": {
-    "jquery": ">=1.7.1 && <=2.1.3",
+    "jquery": "1.7.1 - 2.1.3",
     "moment": ">=2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I noticed that JQuery 3.0 is automatically pulled when you do `bower install fullcalendar`. There are still a lot of bugs, seeing as JQuery 3.0 is so new, so it seems like it would be a good idea for the time being to lock it to a known supported version.

I chose 2.1.3, as that's what appears to be used in the help doc examples, such as [this](http://fullcalendar.io/views/agendaWeek/) here.

Only found this project recently, so I'm not sure if the latest JQuery 2.x is okay.