### PR TITLE
add getEventSource method

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -17,6 +17,7 @@ function EventManager(options) { // assumed to be a calendar
 	// exports
 	t.isFetchNeeded = isFetchNeeded;
 	t.fetchEvents = fetchEvents;
+	t.getEventSource = getEventSource;
 	t.addEventSource = addEventSource;
 	t.removeEventSource = removeEventSource;
 	t.updateEvent = updateEvent;
@@ -227,7 +228,14 @@ function EventManager(options) { // assumed to be a calendar
 	
 	/* Sources
 	-----------------------------------------------------------------------------*/
-	
+
+
+	function getEventSource(id) {
+		return $.grep(sources, function(src) {
+			return src.id && src.id === id;
+		})[0];
+	}
+
 
 	function addEventSource(sourceInput) {
 		var source = buildEventSource(sourceInput);

--- a/tests/automated/getEventSource.js
+++ b/tests/automated/getEventSource.js
@@ -1,0 +1,47 @@
+describe('getEventSource', function() {
+	var options;
+	var calendarEl;
+
+	beforeEach(function() {
+		affix('#cal');
+		calendarEl = $('#cal');
+		options = {
+			now: '2015-08-07',
+			defaultView: 'agendaWeek',
+			eventSources: [
+				{
+					events: [
+						{ id: 1, start: '2015-08-07T02:00:00', end: '2015-08-07T03:00:00', title: 'event A' }
+					],
+					id: 'source1'
+				},
+				{
+					events: [
+						{ id: 2, start: '2015-08-07T03:00:00', end: '2015-08-07T04:00:00', title: 'event B' }
+					],
+					id: 'source2'
+				},
+				{
+					events: [
+						{ id: 3, start: '2015-08-07T04:00:00', end: '2015-08-07T05:00:00', title: 'event C' }
+					],
+					id: 'source3'
+				}
+			]
+		};
+	});
+
+	it('does not mutate when removeEventSource is called', function(done) {
+		var eventSource;
+
+		calendarEl.fullCalendar(options);
+
+		eventSource = calendarEl.fullCalendar('getEventSource', 'source1');
+		expect(typeof eventSource).toBe('object');
+
+		calendarEl.fullCalendar('removeEventSource', eventSource);
+		expect(typeof eventSource).toBe('object'); // instead of 'undefined'
+
+		done();
+	});
+});

--- a/tests/automated/getEventSource.js
+++ b/tests/automated/getEventSource.js
@@ -31,16 +31,17 @@ describe('getEventSource', function() {
 		};
 	});
 
-	it('does not mutate when removeEventSource is called', function(done) {
-		var eventSource;
+	it('retreives the queried event source', function(done) {
+		var eventSource1;
+		var eventSource2;
 
 		calendarEl.fullCalendar(options);
 
-		eventSource = calendarEl.fullCalendar('getEventSource', 'source1');
-		expect(typeof eventSource).toBe('object');
+		eventSource1 = calendarEl.fullCalendar('getEventSource', 'source1');
+		eventSource2 = calendarEl.fullCalendar('getEventSource', 'source2');
 
-		calendarEl.fullCalendar('removeEventSource', eventSource);
-		expect(typeof eventSource).toBe('object'); // instead of 'undefined'
+		expect(eventSource1.id).toBe('source1');
+		expect(eventSource2.id).toBe('source2');
 
 		done();
 	});


### PR DESCRIPTION
This method retrieves a single event source as discussed in #2433. If there are multiple event sources with same ID, the first event source is retrieved (even though that's technically invalid, as IDs should be unique).

See an example here: http://embed.plnkr.co/HFwUWbNIS5SbeQ1JnZUw/. Clicking the `getEventSource` button adds the event source with ID `source1` to the console.