### PR TITLE
Default firstDay to 1 for ISO week calculation

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -314,11 +314,6 @@ function Calendar_constructor(element, overrides) {
 	if (options.dayNamesShort) {
 		localeData._weekdaysShort = options.dayNamesShort;
 	}
-	if (options.firstDay != null) {
-		var _week = createObject(localeData._week); // _week: { dow: # }
-		_week.dow = options.firstDay;
-		localeData._week = _week;
-	}
 
 	// assign a normalized value, to be used by our .week() moment extension
 	localeData._fullCalendar_weekCalc = (function(weekCalc) {
@@ -333,6 +328,16 @@ function Calendar_constructor(element, overrides) {
 		}
 	})(options.weekNumberCalculation);
 
+	var _week = createObject(localeData._week); // _week: { dow: # }
+	if (options.firstDay != null) {
+		_week.dow = options.firstDay;
+	}
+	else {
+		if (localeData._fullCalendar_weekCalc === 'ISO') {
+			_week.dow = 1;
+		}
+	}
+	localeData._week = _week;
 
 
 	// Calendar-specific Date Utilities


### PR DESCRIPTION
**From commit message**

ISO 8601 defines Monday as the first day of the week. This means that when setting `weekNumberCalculation: 'ISO'`, week numbers will change on Monday, regardless of the locale used.

However, some locales define another day as first day of the week (`dow`). As said, that will not influence ISO week number calculation, but it _does_ determine the day on which each week row starts in the calendar display (which day is in the left-most day column).

This can lead to a single row in the calendar having a week number change somewhere halfway down the week. For example, a calendar row displaying Sunday through Saturday according to US English locale, with the week number changing on Monday according to ISO 8601 week number calculation. Then when displaying week numbers alongside (in a separate column), it becomes difficult to know which days of a row belong to which week number.

It was already possible to solve this by setting `firstDay: 1`, which overrides the locale's first day of the week (`dow`), which will in turn result in calendar rows starting on Monday.

This commit implements the suggestion by arshaw to extend the above by assuming a default value of `1` in case `weekNumberCalculation` is set to `'ISO'`, but `firstDay` has not been set.

This change will affect all users with the following combination of settings:
- `weekNumberCalculation: 'ISO'`, _and_
- `lang` either not set, or set to a locale that does not define Monday as the first day of the week (for example `lang: 'en'` or `lang: 'en-us'`), _and_
- `firstDay` not set.

Regardless of whether `weekNumbers: true` is set or not.

These users will have the start day of their calendar (what day is displayed in the left-most day column) changed from the locale-defined first day (e.g. Sunday) to Monday. To have the calendar start at the locale-defined first day of the week again, they will need to set `firstDay`. ISO week number calculation will not be influenced by that.