### PR TITLE
Travis: add style checks to CI and speed up runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: node_js
 node_js:
   - 'node' # implies latest version
 
+cache:
+  directories:
+  - node_modules
+  - lib
+
 env:
   - CMD=test
   - CMD=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,11 @@ language: node_js
 node_js:
   - 'node' # implies latest version
 
+env:
+  - CMD=test
+  - CMD=lint
+
 before_script:
   - bower install
+
+script: npm run $CMD

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "CONTRIBUTING.*"
   ],
   "scripts": {
-    "test" : "grunt dev && grunt karma:single"
+    "test" : "grunt dev && grunt karma:single",
+    "lint" : "grunt check"
   }
 }

--- a/tests/automated/refetchEvents.js
+++ b/tests/automated/refetchEvents.js
@@ -91,7 +91,11 @@ describe('refetchEvents', function() {
 				// set a 100ms timeout on this event source
 				options.eventSources[0].events = function(start, end, timezone, callback) {
 					var events = [
-						{ id: '1', start: '2015-08-07T02:00:00', end: '2015-08-07T03:00:00', title: 'event A', className: 'fetch' + fetchCount }
+						{ id: '1',
+						  start: '2015-08-07T02:00:00',
+						  end: '2015-08-07T03:00:00',
+						  title: 'event A', className: 'fetch' + fetchCount
+						}
 					];
 
 					setTimeout(function() {
@@ -123,7 +127,13 @@ describe('refetchEvents', function() {
 		function createEventGenerator() {
 			return function(start, end, timezone, callback) {
 				var events = [
-					{ id: 1, start: '2015-08-07T02:00:00', end: '2015-08-07T03:00:00', title: 'event A', className: 'fetch' + fetchCount }
+					{
+					  id: 1,
+					  start: '2015-08-07T02:00:00',
+					  end: '2015-08-07T03:00:00',
+					  title: 'event A',
+					  className: 'fetch' + fetchCount
+					}
 				];
 
 				callback(events);

--- a/tests/automated/removeEventSource.js
+++ b/tests/automated/removeEventSource.js
@@ -56,21 +56,21 @@ describe('removeEventSource', function() {
 
 		var source1 = function(start, end, timezone, callback) {
 			setTimeout(function() {
-				callback([{
+				callback([ {
 					title: 'event1',
 					className: 'event1',
 					start: '2014-08-01T02:00:00'
-				}]);
+				} ]);
 			}, 100);
 		};
 
 		var source2 = function(start, end, timezone, callback) {
 			setTimeout(function() {
-				callback([{
+				callback([ {
 					title: 'event2',
 					className: 'event2',
 					start: '2014-08-01T02:00:00'
-				}]);
+				} ]);
 			}, 100);
 		};
 
@@ -94,10 +94,10 @@ describe('removeEventSource', function() {
 
 	describe('when multiple sources share the same fetching function', function() {
 		var fetchFunc = function(start, end, timezone, callback) {
-			callback([{
+			callback([ {
 				title: 'event',
 				start: '2014-08-01T02:00:00'
-			}]);
+			} ]);
 		};
 		beforeEach(function() {
 			options.eventSources = [

--- a/tests/automated/removeEventSources.js
+++ b/tests/automated/removeEventSources.js
@@ -41,11 +41,11 @@ describe('removeEventSources', function() {
 		return {
 			id: id,
 			events: function(start, end, timezone, callback) {
-				callback([{
+				callback([ {
 					title: 'event' + id,
 					className: 'event' + id,
 					start: '2014-08-01T02:00:00'
-				}]);
+				} ]);
 			}
 		};
 	}


### PR DESCRIPTION
This should speed up subsequent runs by caching `node_modules` and `lib`.

Additionally, this adds linting to Travis, and fixes existing lint problems in the tests.

----

Example run: https://travis-ci.org/avindra/fullcalendar/builds/143421961