### PR TITLE
Add lang option rename to changelog (v3-beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Breaking Changes:
 - IE8 support dropped
 - jQuery: minimum support raised to v2.0.0
 - MomentJS: minimum support raised to v2.9.0
+- `lang` option renamed to `locale`
 - dist files have been renamed to be more consistent with MomentJS:
 	- `lang/` -> `locale/`
 	- `lang-all.js` -> `locale-all.js`


### PR DESCRIPTION
The only thing that surprised me in v3-beta was the renaming of the `lang` option to `locale`. Assuming you do not want to support `lang` as a deprecated alternative name, perhaps this change can be listed with the Breaking Changes in the Changelog (now it only mentions the renaming of the dist/lang-files).