### PR TITLE
Allow the event to add classes to the title span.

### DIFF
--- a/src/common/DayGrid.events.js
+++ b/src/common/DayGrid.events.js
@@ -114,7 +114,7 @@ DayGrid.mixin({
 		}
 
 		titleHtml =
-			'<span class="fc-title">' +
+			'<span class="fc-title ' + event.titleClass + '">' +
 				(htmlEscape(event.title || '') || '&nbsp;') + // we always want one line of height
 			'</span>';
 		
@@ -246,7 +246,7 @@ DayGrid.mixin({
 		// Give preference to elements with certain criteria, so they have
 		// a chance to be closer to the top.
 		this.sortEventSegs(segs);
-		
+
 		for (i = 0; i < segs.length; i++) {
 			seg = segs[i];
 

--- a/src/common/TimeGrid.events.js
+++ b/src/common/TimeGrid.events.js
@@ -295,7 +295,7 @@ TimeGrid.mixin({
 						''
 						) +
 					(event.title ?
-						'<div class="fc-title">' +
+						'<div class="fc-title ' + event.titleClass + '">' +
 							htmlEscape(event.title) +
 						'</div>' :
 						''


### PR DESCRIPTION
This enables the ability to prefix an icon to the event using CSS ::before. 

The event can now define a "titleClass" to be added to the event title span. 

See #1009 
