### PR TITLE
Add .fc scope to table print styles

### DIFF
--- a/src/common/print.css
+++ b/src/common/print.css
@@ -32,11 +32,11 @@
 /* Table & Day-Row Restyling
 --------------------------------------------------------------------------------------------------*/
 
-th,
-td,
-hr,
-thead,
-tbody,
+.fc th,
+.fc td,
+.fc hr,
+.fc thead,
+.fc tbody,
 .fc-row {
 	border-color: #ccc !important;
 	background: #fff !important;


### PR DESCRIPTION
Fullcalendar's print stylesheet was overriding table styles globally. This commit scopes the rules.

Updated #3303 for 3.0.0.
I have compared month/agendaDay view printouts before and after the change and they match.