### PR TITLE
l10n fix

### DIFF
--- a/locale/de.js
+++ b/locale/de.js
@@ -10,5 +10,5 @@ $.fullCalendar.locale("de", {
 	eventLimitText: function(n) {
 		return "+ weitere " + n;
 	},
-	noEventsMessage: "Keine Ereignisse anzeigen"
+	noEventsMessage: "Keine Ereignisse anzuzeigen"
 });


### PR DESCRIPTION
The translated message said "display no events", but should say "no events to display"