### PR TITLE
Include list option in documentation

### DIFF
--- a/text/buttonText.txt
+++ b/text/buttonText.txt
@@ -11,10 +11,13 @@ Object, *default*:
 		today:    'today',
 		month:    'month',
 		week:     'week',
-		day:      'day'
+		day:      'day',
+		list:     'list'
 	}
 </div>
 
 [buttonIcons](../display/buttonIcons) and [themeButtonIcons](../display/themeButtonIcons) affects the appearance of certain other buttons.
+
+Note: The list property is only used in fullCalendar v3 and later.
 
 HTML injection is not supported. All special characters will be escaped.


### PR DESCRIPTION
Update the buttonText documentation to include list for the List View button.
