### PR TITLE
rendering hooks for day heading

### DIFF
--- a/src/common/DayTableMixin.js
+++ b/src/common/DayTableMixin.js
@@ -67,8 +67,8 @@ var DayTableMixin = FC.DayTableMixin = {
 
 		this.colHeadFormat = this.view.opt('columnFormat');
 		if (this.colHeadFormat !== false) {
-		    this.colHeadFormat = this.colHeadFormat || this.computeColHeadFormat();
-	    }
+			this.colHeadFormat = this.colHeadFormat || this.computeColHeadFormat();
+		}
 	},
 
 
@@ -298,9 +298,9 @@ var DayTableMixin = FC.DayTableMixin = {
 	// (colspan should be no different)
 	renderHeadDateCellHtml: function(date, colspan, otherAttrs) {
 
-        if (this.colHeadFormat === false) {
-            return '';
-        }
+		if (this.colHeadFormat === false) {
+			return '';
+		}
 
 		var view = this.view;
 		var classNames = [
@@ -320,10 +320,10 @@ var DayTableMixin = FC.DayTableMixin = {
 			classNames.push('fc-' + dayIDs[date.day()]); // only add the day-of-week class
 		}
 
-        var headerHtml = typeof this.colHeadFormat === 'function' ? this.colHeadFormat(date, colspan, otherAttrs) : htmlEscape(date.format(this.colHeadFormat));
+		var headerHtml = typeof this.colHeadFormat === 'function' ? this.colHeadFormat(date, colspan, otherAttrs) : htmlEscape(date.format(this.colHeadFormat));
 
 		return '' +
-            '<th class="' + classNames.join(' ') + '"' +
+			'<th class="' + classNames.join(' ') + '"' +
 				(this.rowCnt === 1 ?
 					' data-date="' + date.format('YYYY-MM-DD') + '"' :
 					'') +

--- a/src/common/DayTableMixin.js
+++ b/src/common/DayTableMixin.js
@@ -64,7 +64,11 @@ var DayTableMixin = FC.DayTableMixin = {
 	// Computes and assigned the colCnt property and updates any options that may be computed from it
 	updateDayTableCols: function() {
 		this.colCnt = this.computeColCnt();
-		this.colHeadFormat = this.view.opt('columnFormat') || this.computeColHeadFormat();
+
+		this.colHeadFormat = this.view.opt('columnFormat');
+		if (this.colHeadFormat !== false) {
+		    this.colHeadFormat = this.colHeadFormat || this.computeColHeadFormat();
+	    }
 	},
 
 
@@ -293,6 +297,11 @@ var DayTableMixin = FC.DayTableMixin = {
 	// TODO: when internalApiVersion, accept an object for HTML attributes
 	// (colspan should be no different)
 	renderHeadDateCellHtml: function(date, colspan, otherAttrs) {
+
+        if (this.colHeadFormat === false) {
+            return '';
+        }
+
 		var view = this.view;
 		var classNames = [
 			'fc-day-header',
@@ -311,6 +320,8 @@ var DayTableMixin = FC.DayTableMixin = {
 			classNames.push('fc-' + dayIDs[date.day()]); // only add the day-of-week class
 		}
 
+        var headerHtml = typeof this.colHeadFormat === 'function' ? this.colHeadFormat(date, colspan, otherAttrs) : htmlEscape(date.format(this.colHeadFormat));
+
 		return '' +
             '<th class="' + classNames.join(' ') + '"' +
 				(this.rowCnt === 1 ?
@@ -326,7 +337,7 @@ var DayTableMixin = FC.DayTableMixin = {
 				// don't make a link if the heading could represent multiple days, or if there's only one day (forceOff)
 				view.buildGotoAnchorHtml(
 					{ date: date, forceOff: this.rowCnt > 1 || this.colCnt === 1 },
-					htmlEscape(date.format(this.colHeadFormat)) // inner HTML
+					headerHtml // inner HTML
 				) +
 			'</th>';
 	},

--- a/tests/automated/columnFormat.js
+++ b/tests/automated/columnFormat.js
@@ -197,4 +197,33 @@ describe('columnFormat', function() {
             expect($('.fc-day-header:first')).toHaveText('Thu 12/25');
         });
     });
+
+    describe('columnHeader different options', function() {
+        it('should not render at all when false', function() {
+
+            $('#cal').fullCalendar({
+                columnFormat: false,
+                defaultView: 'agendaWeek'
+            });
+
+            var header = $('#cal th.fc-day-header');
+
+            expect(header.length).toEqual(0);
+        });
+
+        it('should render the method content', function() {
+
+            $('#cal').fullCalendar({
+                defaultView: 'agendaWeek',
+                columnFormat: function(date, colspan, otherAttrs) {
+                    return '<span class="custom"><span>';
+                }
+            });
+
+            var header = $('#cal th.fc-day-header .custom');
+
+            expect(header.length).toEqual(7);
+        });
+    });
+
 });


### PR DESCRIPTION
Too bad i could not make it in time for 3.1.0

It should satisfy all the needs in every issues.

i was wondering if i should skip all the ```<tr>``` in ```renderHeadTrHtml``` when columnFormat is false

-----

this is a solution for the following issues: #3078, #3331, #3438