### PR TITLE
Use target property alongside url property with anchor tag

### DIFF
--- a/src/common/DayGrid.events.js
+++ b/src/common/DayGrid.events.js
@@ -123,6 +123,10 @@ DayGrid.mixin({
 					' href="' + htmlEscape(event.url) + '"' :
 					''
 					) +
+                (event.url && event.target ?
+                    ' target="' + htmlEscape(event.target) + '"' :
+                    ''
+                ) +
 				(skinCss ?
 					' style="' + skinCss + '"' :
 					''

--- a/src/common/TimeGrid.events.js
+++ b/src/common/TimeGrid.events.js
@@ -279,6 +279,10 @@ TimeGrid.mixin({
 				' href="' + htmlEscape(event.url) + '"' :
 				''
 				) +
+            (event.url && event.target ?
+                ' target="' + htmlEscape(event.target) + '"' :
+                ''
+                ) +
 			(skinCss ?
 				' style="' + skinCss + '"' :
 				''


### PR DESCRIPTION
It is great that the latest version of FullCalendar outputs items on the calendar as proper <a> tags.  I like the way it searches for a property called "url" on the data element and uses it to set the href attribute on the <a> tag.  However, in some applications, I need to be able to specify that the url should open in a new window/tab, so I propose that we look for a "target" property alongside the url element, and if it is found, use it to set the target attribute on the <a> tag.