### PR TITLE
add week to similarUnitMap (also fixes issue 2371)

### DIFF
--- a/src/date-formatting.js
+++ b/src/date-formatting.js
@@ -150,6 +150,8 @@ function formatRangeWithChunks(date1, date2, chunks, separator, isRTL) {
 var similarUnitMap = {
 	Y: 'year',
 	M: 'month',
+	w: 'week', // week of year
+	W: 'week', // week of year (ISO)
 	D: 'day', // day of month
 	d: 'day', // day of week
 	// prevents a separator between anything time-related...
@@ -162,7 +164,6 @@ var similarUnitMap = {
 	m: 'second', // minute
 	s: 'second' // second
 };
-// TODO: week maybe?
 
 
 // Given a formatting chunk, and given that both dates are similar in the regard the

--- a/tests/automated/formatRange.js
+++ b/tests/automated/formatRange.js
@@ -41,6 +41,11 @@ describe('formatRange', function() {
 		expect(s).toEqual('January 1st 2014');
 	});
 
+	it('outputs the single week number when dates have the same week and format string is week', function() {
+		var s = $.fullCalendar.formatRange('2014-01-01', '2014-01-01', 'W');
+		expect(s).toEqual('1');
+	});
+
 	it('uses a custom separator', function() {
 		var s = $.fullCalendar.formatRange(
 			'2014-01-01T06:00:00',


### PR DESCRIPTION
I humbly request that this change be merged into master. It fixes a problem I'm encountering where week numbers are duplicated in the title, when the start and end weeks for a view are equal.

If not, can you guys elaborate on why it should not be merged? I can see the bug ( https://github.com/fullcalendar/fullcalendar/issues/2636 ) has been open for quite a while now, and it's marked as "todo" in the code.