### PR TITLE
support Buddhist year format string

### DIFF
--- a/src/date-formatting.js
+++ b/src/date-formatting.js
@@ -39,6 +39,9 @@ var specialTokens = {
 	},
 	T: function(date) { // "A" or "P"
 		return oldMomentFormat(date, 'A').charAt(0);
+	},
+	B: function(date) {
+		return date.year() + 543;
 	}
 };
 
@@ -48,6 +51,7 @@ The first characters of formatting tokens for units that are 1 day or larger.
 `unit` is a normalized unit, used for comparing moments.
 */
 var largeTokenMap = {
+	B: { value: 1, unit: 'year' },
 	Y: { value: 1, unit: 'year' },
 	M: { value: 2, unit: 'month' },
 	W: { value: 3, unit: 'week' }, // ISO week

--- a/tests/automated/formatRange.js
+++ b/tests/automated/formatRange.js
@@ -173,4 +173,13 @@ describe('formatRange', function() {
 		expect(s).toEqual('January 1st 2014 - January 1st 2015');
 	});
 
+	it('doesn\'t do any splitting when dates have same year', function() {
+		var s = $.fullCalendar.formatRange(
+			moment.utc('2017-01-01'),
+			moment.utc('2017-01-01'),
+			'MMMM B'
+		);
+		expect(s).toEqual('January 2560');
+	});
+
 });

--- a/tests/automated/moment-formatting.js
+++ b/tests/automated/moment-formatting.js
@@ -71,4 +71,10 @@ describe('moment date formatting', function() {
 		expect(s).toEqual('November 11th 2014, 12(:00)');
 	});
 
+	it('should output Buddhist year with the \'B\' formatting character', function() {
+		var mom1 = $.fullCalendar.moment.utc('2017-02-16T06:00:00');
+		var s1 = mom1.format('MMMM B');
+		expect(s1).toEqual('February 2560');
+	});
+
 });


### PR DESCRIPTION
support Buddhist year format string by adding `B` to `specialTokens`.

need to add `B` to largeTokenMap to make formatRange works properly.