### PR TITLE
Enabled setting of minSegHeight

### DIFF
--- a/src/common/TimeGrid.events.js
+++ b/src/common/TimeGrid.events.js
@@ -468,8 +468,8 @@ TimeGrid.mixin({
 			seg = segs[i];
 			seg.el.css(this.generateFgSegHorizontalCss(seg));
 
-			// if the height is short, add a className for alternate styling
-			if (seg.bottom - seg.top < 30) {
+			// if the height is short (or shorter than set in view options), add a className for alternate styling
+			if (seg.bottom - seg.top < (this.view.opt('minSegHeight') || 15)*2 ) {
 				seg.el.addClass('fc-short');
 			}
 		}


### PR DESCRIPTION
Enables to set minSegHeight in view options, in order to customize the
minimum height causing the event to split text in 2 lines (one for the
time, the other for the content)