### PR TITLE
Bug with nested inverse-background events (test & fix included)

### DIFF
--- a/src/common/Grid.events.js
+++ b/src/common/Grid.events.js
@@ -1275,7 +1275,9 @@ Grid.mixin({
 				});
 			}
 
-			start = range.end;
+			if (range.end > start) {
+				start = range.end;
+			}
 		}
 
 		// add the span of time after the last event (if there is any)

--- a/tests/automated/background-events.js
+++ b/tests/automated/background-events.js
@@ -625,6 +625,40 @@ describe('background events', function() {
 					};
 					$('#cal').fullCalendar(options);
 				});
+
+				it('render correctly with two related events, nested', function(done) {
+					options.events = [
+						{
+							id: 'hello',
+							start: '2014-11-05T01:00:00',
+							end: '2014-11-05T05:00:00',
+							rendering: 'inverse-background'
+						},
+						{
+							id: 'hello',
+							start: '2014-11-05T02:00:00',
+							end: '2014-11-05T04:00:00',
+							rendering: 'inverse-background'
+						}
+					];
+					options.eventAfterAllRender = function() {
+						expect($('.fc-bgevent').length).toBe(8);
+						expect(queryBgEventsInCol(0).length).toBe(1);
+						expect(queryBgEventsInCol(1).length).toBe(1);
+						expect(queryBgEventsInCol(2).length).toBe(1);
+						expect(queryBgEventsInCol(3).length).toBe(2);
+						expect(queryBgEventsInCol(4).length).toBe(1);
+						expect(queryBgEventsInCol(5).length).toBe(1);
+						expect(queryBgEventsInCol(6).length).toBe(1);
+
+						expect($('.fc-bgevent:eq(3)')).toBeAbove('.fc-slats tr:eq(2)'); // first part before 1am
+						expect($('.fc-bgevent:eq(4)')).toBeBelow('.fc-slats tr:eq(9)'); // second part after 5am
+
+						done();
+					};
+					$('#cal').fullCalendar(options);
+				});
+
 			});
 
 			describe('when RTL', function() {


### PR DESCRIPTION
### The bug
I found a bug with inverse-background events when 2 events have the same id and one range is included in the other.
For instance, with a range = 2am → 7am and a range = 3am → 5am, you would expect the result of `invertRanges()` to be 
``` js
[
  {
    "start": "2017-03-07",
    "end": "2017-03-07T02:00:00"
  },
  {
    "start": "2017-03-07T07:00:00",
    "end": "2017-03-08"
  }
]
```
but it is 
``` js
[
  {
    "start": "2017-03-07",
    "end": "2017-03-07T02:00:00"
  },
  {
    "start": "2017-03-07T05:00:00",
    "end": "2017-03-08"
  }
]
```

Here is a codepen demonstrating this: http://codepen.io/floriancargoet/pen/gmQePw

### The fix

When you check the execution of the `invertRanges` function, you can see that after sorting the ranges we have `ranges = [2am → 7am , 3am → 5am]`. Then we push (viewStart → 2am) in the `inverseRanges` array, set `start = range.end = 7am`. Then we check the 2nd range, and set `start = range.end = 5am`. That's where the problem is. The algorithm went back in time and forgot that 5am → 7am was already covered by the first range.

I think we should not go back in time and the fix is simple, we should add an `if`:
``` js			
if (range.end > start) {
  start = range.end;
}
```

I've added a failing test in the first commit and the fix (which passes the test) in the second commit.
