### PR TITLE
Add composer.js to let PHP developers to keep track of fullcalendar on packagist.org.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "fullcalendar/fullcalendar",
+    "description": "Full-sized drag & drop event calendar",
+    "authors": [
+        {
+          "name": "Adam Shaw",
+          "email": "arshaw@arshaw.com",
+          "homepage": "http://arshaw.com/"
+        }
+    ],
+    "keywords": [
+        "calendar",
+        "event",
+        "full-sized",
+        "jquery-plugin"
+    ],
+    "type": "library",
+    "license": "MIT",
+    "minimum-stability": "stable",
+    "homepage": "https://fullcalendar.io/",
+    "require": {
+        "components/jquery": "^3.1.0",
+        "moment/moment": "^2.9.0"
+    }
+}


### PR DESCRIPTION
Hello!

Related to #2999 

This piece is necessary to have fullcalendar package on packagist.org. Unfortunately, there are some steps I can't do for you, like create an account in packagist.org, submit your package and wire packagist to github webhooks. But it takes less than 10 minutes.

The `name` info on composer.json should be equals to your account name and package name on packagist.org.

It would be awesome to have your library on packagist.

Thank you!!