### PR TITLE
Fix toISOString for locales with non-trivial postformatting

### DIFF
--- a/src/moment-ext.js
+++ b/src/moment-ext.js
@@ -311,10 +311,10 @@ newMomentProto.format = function() {
 
 newMomentProto.toISOString = function() {
 	if (this._ambigTime) {
-		return oldMomentFormat(this, 'YYYY-MM-DD');
+		return oldMomentFormat(moment(this).locale('en'), 'YYYY-MM-DD');
 	}
 	if (this._ambigZone) {
-		return oldMomentFormat(this, 'YYYY-MM-DD[T]HH:mm:ss');
+		return oldMomentFormat(moment(this).locale('en'), 'YYYY-MM-DD[T]HH:mm:ss');
 	}
 	return oldMomentProto.toISOString.apply(this, arguments);
 };

--- a/tests/automated/moment-ambig.js
+++ b/tests/automated/moment-ambig.js
@@ -26,6 +26,11 @@ describe('ambiguously-zoned moment', function() {
 		expect(mom.toISOString()).toBe('2014-06-08T10:00:00');
 	});
 
+	it('formats via toISOString for locales with non-trivial formatting', function() {
+		var mom = $.fullCalendar.moment.parseZone('2014-06-08T10:00:00').locale('ar');
+		expect(mom.toISOString()).toBe('2014-06-08T10:00:00');
+	});
+
 	it('is correctly cloned', function() {
 		var mom = $.fullCalendar.moment.parseZone('2014-06-08T10:00:00');
 		var clone = mom.clone();


### PR DESCRIPTION
Some locales do a post-processing step when formatting. For example Arabic does that:

```javascript
$.fullCalendar.moment.parseZone('2014-06-08T10:00:00').locale('ar').format()
// result: "٢٠١٤-٠٦-٠٨T١٠:٠٠:٠٠"
```

There is a bug in `moment-ext.js` which causes calls to `toISOString` use this post-processing:

```javascript
$.fullCalendar.moment.parseZone('2014-06-08T10:00:00').locale('ar').toISOString()
// result: "٢٠١٤-٠٦-٠٨T١٠:٠٠:٠٠"
// expected: "2014-06-08T10:00:00"
```

This PR introduces a test for that and attempts to fix the issue in a pretty ugly way.