### PR TITLE
Added hack fix for jquery-ui selectable bug

### DIFF
--- a/src/common/common.css
+++ b/src/common/common.css
@@ -14,6 +14,10 @@
 	text-align: right;
 }
 
+body { /* jquery-ui selectable bug HACK fix */
+	overflow-x: visible !important!;	
+}
+
 body .fc { /* extra precedence to overcome jqui */
 	font-size: 1em;
 }


### PR DESCRIPTION
Bug fix for this issue I created: https://github.com/fullcalendar/fullcalendar/issues/3615

Bin: http://jsbin.com/kufidajona/edit?output

Actual issue is, some dates are not clickable/selectable because of a jquery-ui bug.

Sometimes just the `overflow-x` alone can result in this bug and sometimes (like in the Bin) needs the `height: 100%` on `html` and `body`

Others will end up doing it this way anyway, why not add it in the core? I suffered for 1 week because of this lol.

Sounds weird but hey... it's a hack. Can't even explain why.