### PR TITLE
Use a dynamically set duration object if available

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -140,8 +140,8 @@ var Calendar = FC.Calendar = Class.extend({
 		}
 
 		// fall back to top-level `duration` option
-		durationInput = durationInput ||
-			this.dynamicOverrides.duration ||
+		durationInput = this.dynamicOverrides.duration ||
+			durationInput ||
 			this.overrides.duration;
 
 		if (durationInput) {


### PR DESCRIPTION
Right now setting a duration dynamically is ignored. Example below.
`$('#calendar').fullCalendar('option', 'duration', { weeks: 10 })` 

This change will use the dynamic override in the first place.