### PR TITLE
Set isComputed = true when scrollTime option is set

### DIFF
--- a/src/common/View.js
+++ b/src/common/View.js
@@ -668,8 +668,10 @@ var View = FC.View = Class.extend(EmitterMixin, ListenerMixin, {
 		if (!(this.capturedScrollDepth++)) {
 			this.capturedScroll = this.isDateRendered ? this.queryScroll() : {}; // require a render first
 
-			if(this.opt('scrollTime') != ''){
-				this.capturedScroll.isComputed = true;
+			if(this.capturedScroll){
+				if(this.opt('scrollTime') != '' && this.captureScroll.left == 0){
+					this.capturedScroll.isComputed = true;
+				}
 			}
 			return true; // root?
 		}

--- a/src/common/View.js
+++ b/src/common/View.js
@@ -669,7 +669,7 @@ var View = FC.View = Class.extend(EmitterMixin, ListenerMixin, {
 			this.capturedScroll = this.isDateRendered ? this.queryScroll() : {}; // require a render first
 
 			if(this.capturedScroll){
-				if(this.opt('scrollTime') != '' && this.captureScroll.left === 0){
+				if(this.opt('scrollTime') !== '' && this.captureScroll.left === 0){
 					this.capturedScroll.isComputed = true;
 				}
 			}

--- a/src/common/View.js
+++ b/src/common/View.js
@@ -669,7 +669,7 @@ var View = FC.View = Class.extend(EmitterMixin, ListenerMixin, {
 			this.capturedScroll = this.isDateRendered ? this.queryScroll() : {}; // require a render first
 
 			if(this.capturedScroll){
-				if(this.opt('scrollTime') != '' && this.captureScroll.left == 0){
+				if(this.opt('scrollTime') != '' && this.captureScroll.left === 0){
 					this.capturedScroll.isComputed = true;
 				}
 			}

--- a/src/common/View.js
+++ b/src/common/View.js
@@ -667,6 +667,10 @@ var View = FC.View = Class.extend(EmitterMixin, ListenerMixin, {
 	captureScroll: function() {
 		if (!(this.capturedScrollDepth++)) {
 			this.capturedScroll = this.isDateRendered ? this.queryScroll() : {}; // require a render first
+
+			if(this.opt('scrollTime') != ''){
+				this.capturedScroll.isComputed = true;
+			}
 			return true; // root?
 		}
 		return false;

--- a/tests/automated/columnFormat.js
+++ b/tests/automated/columnFormat.js
@@ -116,8 +116,8 @@ describe('columnFormat', function() {
     describe('when locale is Korean', function() {
 
         var viewWithFormat = [ { view: 'month', expected: '일', selector: 'th.fc-day-header.fc-sun' },
-            { view: 'basicWeek', expected: '일 5.11', selector: 'th.fc-day-header.fc-sun' },
-            { view: 'agendaWeek', expected: '일 5.11', selector: 'th.fc-widget-header.fc-sun' },
+            { view: 'basicWeek', expected: '일 05.11', selector: 'th.fc-day-header.fc-sun' },
+            { view: 'agendaWeek', expected: '일 05.11', selector: 'th.fc-widget-header.fc-sun' },
             { view: 'basicDay', expected: '일요일', selector: 'th.fc-day-header.fc-sun' },
             { view: 'agendaDay', expected: '일요일', selector: 'th.fc-widget-header.fc-sun' } ];
 


### PR DESCRIPTION
when scrollTime is set, I noticed that the scroll bar will move to the set time based on 
```
releaseScroll: 

...
if(scroll.isComputed)
```

However, the scroll object depends on this.capturedScroll(), which depends on this.queryScroll()

this.queryScroll() will never return an object with isComputed property.

Thus, I am making this fix so that the scroll bar will not be reset to left:0, top:0.
 