### PR TITLE
Bug with out of range inverse-background events (test & fix included)

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -78,6 +78,7 @@ function EventManager() { // assumed to be a calendar
 	function filterEventsWithinRange(events) {
 		var filteredEvents = [];
 		var i, event;
+
 		for (i = 0; i < events.length; i++) {
 			event = events[i];
 			// inverse-background events are always rendered

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -78,11 +78,11 @@ function EventManager() { // assumed to be a calendar
 	function filterEventsWithinRange(events) {
 		var filteredEvents = [];
 		var i, event;
-
 		for (i = 0; i < events.length; i++) {
 			event = events[i];
-
+			// inverse-background events are always rendered
 			if (
+				event.rendering === 'inverse-background' ||
 				event.start.clone().stripZone() < rangeEnd &&
 				t.getEventEnd(event).stripZone() > rangeStart
 			) {

--- a/tests/legacy/background-events.js
+++ b/tests/legacy/background-events.js
@@ -687,8 +687,8 @@ describe('background events', function() {
 				});
 			});
 
-			describe('when out of view range', function () {
-				it('should still render', function (done) {
+			describe('when out of view range', function() {
+				it('should still render', function(done) {
 					options.events = [ {
 						start: '2014-01-01T01:00:00',
 						end: '2014-01-01T05:00:00',
@@ -701,7 +701,7 @@ describe('background events', function() {
 					$('#cal').fullCalendar(options);
 
 				});
-			})
+			});
 		});
 
 		it('can have custom Event Object color', function(done) {

--- a/tests/legacy/background-events.js
+++ b/tests/legacy/background-events.js
@@ -686,6 +686,22 @@ describe('background events', function() {
 					$('#cal').fullCalendar(options);
 				});
 			});
+
+			describe('when out of view range', function () {
+				it('should still render', function (done) {
+					options.events = [ {
+						start: '2014-01-01T01:00:00',
+						end: '2014-01-01T05:00:00',
+						rendering: 'inverse-background'
+					} ];
+					options.eventAfterAllRender = function() {
+						expect($('.fc-bgevent').length).toBe(7);
+						done();
+					};
+					$('#cal').fullCalendar(options);
+
+				});
+			})
 		});
 
 		it('can have custom Event Object color', function(done) {


### PR DESCRIPTION
### The bug
I found a bug with inverse-background events filtering. Since commit 3547ce75 events are filtered out when they are not in the view range. `inverse-background` events should not be filtered out since their behaviour is to appear everywhere outside [start; end].

Here is a codepen demonstrating this: http://codepen.io/floriancargoet/pen/bWBOJN

### The fix
Do not filter out `inverse-background` events in `filterEventsWithinRange(events)`:
```js
	function filterEventsWithinRange(events) {
		var filteredEvents = [];
		var i, event;
		for (i = 0; i < events.length; i++) {
			event = events[i];
			// inverse-background events are always rendered
			if (
				event.rendering === 'inverse-background' ||
				event.start.clone().stripZone() < rangeEnd &&
				t.getEventEnd(event).stripZone() > rangeStart
			) {
				filteredEvents.push(event);
			}
		}

		return filteredEvents;
	}
```

I've added a failing test in the first commit and the fix (which passes the test) in the second commit.
