### PR TITLE
Tweak the class for 'today' in the bootstrap theme

### DIFF
--- a/src/theme/BootstrapTheme.js
+++ b/src/theme/BootstrapTheme.js
@@ -12,7 +12,7 @@ var BootstrapTheme = Theme.extend({
 		stateActive: 'active',
 		stateDisabled: 'disabled',
 
-		today: 'alert alert-warning', // the plain `warning` class requires `.table`, too much to ask
+		today: 'alert alert-info', // the plain `info` class requires `.table`, too much to ask
 
 		popover: 'panel panel-default',
 		popoverHeader: 'panel-heading',


### PR DESCRIPTION
I suggest that a more neutral color is used for today's cell highlighting.