### PR TITLE
Fix for the gitignore, and the view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,13 @@ dist
 # npm
 node_modules
 npm-debug.log
+package-lock.json
+
+# yarn
+yarn.lock
+
+# JetBrains
+.idea/
+
+# osx
+.DS_Store

--- a/src/Calendar.render.js
+++ b/src/Calendar.render.js
@@ -230,8 +230,9 @@ Calendar.mixin({
 
 		if (this.view) {
 
-			if (forcedScroll) {
-				this.view.addForcedScroll(forcedScroll);
+			var forced = forcedScroll || (this.optionsModel.get().globalForcedScroll);
+			if (forced) {
+				this.view.addForcedScroll(forced);
 			}
 
 			if (this.elementVisible()) {

--- a/src/agenda/AgendaView.js
+++ b/src/agenda/AgendaView.js
@@ -174,7 +174,9 @@ var AgendaView = FC.AgendaView = View.extend({
 
 		// reset all dimensions back to the original state
 		this.timeGrid.bottomRuleEl.hide(); // .show() will be called later if this <hr> is necessary
-		this.scroller.clear(); // sets height to 'auto' and clears overflow
+		if (!this.options.globalForcedScroll) { // if the globalForcedScroll option is set to true
+			this.scroller.clear(); // sets height to 'auto' and clears overflow
+		}
 		uncompensateScroll(noScrollRowEls);
 
 		// limit number of events in the all-day area


### PR DESCRIPTION
This fix provides a possibility to stop the reset scroll for the agenda.

The fixes are provided as follows:

1. .gitignore is augmented
2. AgendaView is facilitated with the globalForcedScroll condition
3. Calendar render mixin is changed to mention the globalForcedScroll for the isForced state of the view
4. globalForcedScroll can be used for preventing the Agenda scroll reset