### PR TITLE
fix jsEvent not working properly with the unselect callback when selecting another time slot on the calendar view

### DIFF
--- a/src/common/Grid.day-selection.js
+++ b/src/common/Grid.day-selection.js
@@ -11,8 +11,8 @@ Grid.mixin({
 			interactionStart: function() {
 				selectionFootprint = null;
 			},
-			dragStart: function() {
-				_this.view.unselect(); // since we could be rendering a new selection, we want to clear any old one
+			dragStart: function(ev) {
+				_this.view.unselect(ev); // since we could be rendering a new selection, we want to clear any old one
 			},
 			hitOver: function(hit, isOrig, origHit) {
 				var origHitFootprint;


### PR DESCRIPTION
Recreate: http://jsbin.com/bumutohezu/edit?html,js,output

Select a time slot on the calendar. Then, select another. jsEvent is `undefined`.

Fix: https://plnkr.co/edit/rc6LWxR5HS4dCVGGwisz?p=preview