### PR TITLE
Sort event on duration is configurable by isDurationSort boolean. By default it is true

### DIFF
--- a/src/View.js
+++ b/src/View.js
@@ -20,6 +20,7 @@ var View = FC.View = InteractiveDateComponent.extend({
 	selectedEventInstance: null,
 
 	eventOrderSpecs: null, // criteria for ordering events when they have same date/time
+	isDurationSort: null,  // boolean whether to sort events on durations
 
 	// for date utils, computed from options
 	isHiddenDayHash: null,

--- a/src/component/renderers/EventRenderer.js
+++ b/src/component/renderers/EventRenderer.js
@@ -373,8 +373,14 @@ var EventRenderer = Class.extend({
 		var f2 = seg2.footprint.componentFootprint;
 		var r2 = f2.unzonedRange;
 
+        var durationLonger = -1;
+
+        if (this.opt('isDurationSort')) {
+            durationLonger = (r2.endMs - r2.startMs) - (r1.endMs - r1.startMs)
+        }
+
 		return r1.startMs - r2.startMs || // earlier events go first
-			(r2.endMs - r2.startMs) - (r1.endMs - r1.startMs) || // tie? longer events go first
+            durationLonger || // tie? longer events go first
 			f2.isAllDay - f1.isAllDay || // tie? put all-day events first (booleans cast to 0/1)
 			compareByFieldSpecs(
 				seg1.footprint.eventDef,

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -76,6 +76,7 @@ Calendar.defaults = {
 
 	eventOrder: 'title',
 	//eventRenderWait: null,
+	isDurtionSort:true,
 
 	eventLimit: false,
 	eventLimitText: 'more',


### PR DESCRIPTION
Sort event on duration is configurable by isDurationSort boolean. By …default it is true.
For further reading read this
https://stackoverflow.com/questions/46052484/order-events-in-fullcalendar-by-start-date-and-end-date
https://stackoverflow.com/questions/46150370/eventorder-property-of-fullcalendar-io-is-not-working-correctly