### PR TITLE
Check for console.log/warn.apply

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -661,7 +661,7 @@ function isTimeString(str) {
 FC.log = function() {
 	var console = window.console;
 
-	if (console && console.log) {
+	if (console && console.log && console.log.apply) {
 		return console.log.apply(console, arguments);
 	}
 };
@@ -669,7 +669,7 @@ FC.log = function() {
 FC.warn = function() {
 	var console = window.console;
 
-	if (console && console.warn) {
+	if (console && console.warn && console.warn.apply) {
 		return console.warn.apply(console, arguments);
 	}
 	else {


### PR DESCRIPTION
Thanks to IE it seems it's possible for `console.log`/`console.warn` to exist without the `apply` method.

![image](https://user-images.githubusercontent.com/3939997/30489719-9b5a322a-99fd-11e7-8cf4-6f75494e5d5c.png)
