### PR TITLE
Set 'this' context properly in FuncEventSource

### DIFF
--- a/src/models/event-source/FuncEventSource.js
+++ b/src/models/event-source/FuncEventSource.js
@@ -9,7 +9,7 @@ var FuncEventSource = EventSource.extend({
 
 		return Promise.construct(function(onResolve) {
 			_this.func.call(
-				this.calendar,
+				_this.calendar,
 				start.clone(),
 				end.clone(),
 				timezone,


### PR DESCRIPTION
The current code sets the `this` context when invoking the user-defined event source function. However it uses `this.calendar`, which is undefined in the `Promise` callback. It should be using `_this` to access the correct calendar object.

The default implementation is a fairly innocuous bug and won't cause any issues unless the caller tries to use `this` in their event source function. However, if you're in `use strict` mode (i.e. you've included `fullcalendar` as part of a build-chain) the browser will throw errors and stop execution.

https://jsbin.com/sepeparuse/edit?html,js,console,output
