### PR TITLE
Deprecate event shorthand methods

### DIFF
--- a/src/Calendar.render.js
+++ b/src/Calendar.render.js
@@ -94,7 +94,7 @@ Calendar.mixin({
 		this.renderView(this.opt('defaultView'));
 
 		if (this.opt('handleWindowResize')) {
-			$(window).resize(
+			$(window).on("resize",
 				this.windowResizeProxy = debounce( // prevents rapid calls
 					this.windowResize.bind(this),
 					this.opt('windowResizeDelay')

--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -135,7 +135,7 @@ function Toolbar(calendar, toolbarOptions) {
 									buttonInnerHtml +
 								'</button>'
 								)
-								.click(function(ev) {
+								.on("click", function(ev) {
 									// don't process clicks for disabled buttons
 									if (!buttonEl.hasClass(theme.getClass('stateDisabled'))) {
 
@@ -151,7 +151,7 @@ function Toolbar(calendar, toolbarOptions) {
 										}
 									}
 								})
-								.mousedown(function() {
+								.on("mousedown", function() {
 									// the *down* effect (mouse pressed in).
 									// only on buttons that are not the "active" tab, or disabled
 									buttonEl
@@ -159,26 +159,24 @@ function Toolbar(calendar, toolbarOptions) {
 										.not('.' + theme.getClass('stateDisabled'))
 										.addClass(theme.getClass('stateDown'));
 								})
-								.mouseup(function() {
+								.on("mouseup", function() {
 									// undo the *down* effect
 									buttonEl.removeClass(theme.getClass('stateDown'));
 								})
-								.hover(
-									function() {
-										// the *hover* effect.
-										// only on buttons that are not the "active" tab, or disabled
-										buttonEl
-											.not('.' + theme.getClass('stateActive'))
-											.not('.' + theme.getClass('stateDisabled'))
-											.addClass(theme.getClass('stateHover'));
-									},
-									function() {
-										// undo the *hover* effect
-										buttonEl
-											.removeClass(theme.getClass('stateHover'))
-											.removeClass(theme.getClass('stateDown')); // if mouseleave happens before mouseup
-									}
-								);
+								.on("mouseenter", function() {
+									// the *hover* effect.
+									// only on buttons that are not the "active" tab, or disabled
+									buttonEl
+										.not('.' + theme.getClass('stateActive'))
+										.not('.' + theme.getClass('stateDisabled'))
+										.addClass(theme.getClass('stateHover'));
+                                })
+								.on("mouseleave", function() {
+									// undo the *hover* effect
+									buttonEl
+										.removeClass(theme.getClass('stateHover'))
+										.removeClass(theme.getClass('stateDown')); // if mouseleave happens before mouseup
+								});
 
 							groupChildren = groupChildren.add(buttonEl);
 						}


### PR DESCRIPTION
Following jQuery issue #3214
Important for those using jQuery migrate 3.0.1.