### PR TITLE
Guard against missing segment elements

### DIFF
--- a/src/agenda/TimeGrid.js
+++ b/src/agenda/TimeGrid.js
@@ -496,7 +496,7 @@ var TimeGrid = FC.TimeGrid = InteractiveDateComponent.extend(StandardInteraction
 
 		for (i = 0; i < segs.length; i++) {
 			seg = segs[i];
-			seg.el.css(this.generateSegVerticalCss(seg));
+			seg.el && seg.el.css(this.generateSegVerticalCss(seg));
 		}
 	},
 


### PR DESCRIPTION
Since upgrading to 3.6, I'm hitting `Cannot read property 'css' of undefined` errors for some segments, which I have confirmed are indeed missing `el`. The patch is trivial, but I can pin down a repro if necessary.