### PR TITLE
Add a callback filtering instantiated events of business hours

### DIFF
--- a/src/models/BusinessHourGenerator.js
+++ b/src/models/BusinessHourGenerator.js
@@ -23,11 +23,19 @@ var BusinessHourGenerator = FC.BusinessHourGenerator = Class.extend({
 	buildEventInstanceGroup: function(isAllDay, unzonedRange) {
 		var eventDefs = this.buildEventDefs(isAllDay);
 		var eventInstanceGroup;
+		var eventInstances;
 
 		if (eventDefs.length) {
-			eventInstanceGroup = new EventInstanceGroup(
-				eventDefsToEventInstances(eventDefs, unzonedRange)
-			);
+			eventInstances = eventDefsToEventInstances(eventDefs, unzonedRange);
+
+			if (this.calendar.hasPublicHandlers('businessHourEventFilter')) {
+				eventInstances = this.calendar.publiclyTrigger('businessHourEventFilter', {
+					context: this.calendar,
+					args: [ eventInstances ]
+				});
+            }
+
+			eventInstanceGroup = new EventInstanceGroup(eventInstances);
 
 			// so that inverse-background rendering can happen even when no eventRanges in view
 			eventInstanceGroup.explicitEventDef = eventDefs[0];

--- a/tests/legacy/businessHours.js
+++ b/tests/legacy/businessHours.js
@@ -182,8 +182,13 @@ describe('businessHours', function() {
 						end: '16:00'
 					}
 				],
-				businessHourEventFilter: function (events) {
-					return events.filter(function (event) { return event.dateProfile.start.date() != 10; });
+				businessHourEventFilter: function (eventInstances, buildInstancesFunc) {
+					Array.prototype.push.apply(eventInstances,
+						buildInstancesFunc({ date: '2014-12-13', start: '12:00', end: '16:00' }));
+					return eventInstances.filter(function (eventInstance) {
+						// 10th of every month are non-businessday
+						return eventInstance.dateProfile.start.date() != 10;
+					});
 				}
 			});
 
@@ -206,7 +211,8 @@ describe('businessHours', function() {
 				{ start: '2014-12-12T00:00', end: '2014-12-12T10:00' },
 				{ start: '2014-12-12T16:00', end: '2014-12-13T00:00' },
 				// sat
-				{ start: '2014-12-13T00:00', end: '2014-12-14T00:00' }
+				{ start: '2014-12-13T00:00', end: '2014-12-13T12:00' },
+				{ start: '2014-12-13T16:00', end: '2014-12-14T00:00' }
 			])).toBe(true);
 		});
 	});

--- a/tests/legacy/businessHours.js
+++ b/tests/legacy/businessHours.js
@@ -165,6 +165,50 @@ describe('businessHours', function() {
 				{ start: '2014-12-13T00:00', end: '2014-12-14T00:00' }
 			])).toBe(true);
 		});
+
+		it('with event filter', function() {
+			$('#cal').fullCalendar({
+				defaultDate: '2014-12-07',
+				defaultView: 'agendaWeek',
+				businessHours: [
+					{
+						dow: [ 1, 2, 3 ], // mon, tue, wed
+						start: '08:00',
+						end: '18:00'
+					},
+					{
+						dow: [ 4, 5 ], // thu, fri
+						start: '10:00',
+						end: '16:00'
+					}
+				],
+				businessHourEventFilter: function (events) {
+					return events.filter(function (event) { return event.dateProfile.start.date() != 10; });
+				}
+			});
+
+			// timed area
+			expect(isTimeGridNonBusinessSegsRendered([
+				// sun
+				{ start: '2014-12-07T00:00', end: '2014-12-08T00:00' },
+				// mon
+				{ start: '2014-12-08T00:00', end: '2014-12-08T08:00' },
+				{ start: '2014-12-08T18:00', end: '2014-12-09T00:00' },
+				// tue
+				{ start: '2014-12-09T00:00', end: '2014-12-09T08:00' },
+				{ start: '2014-12-09T18:00', end: '2014-12-10T00:00' },
+				// wed
+				{ start: '2014-12-10T00:00', end: '2014-12-11T00:00' },
+				// thu
+				{ start: '2014-12-11T00:00', end: '2014-12-11T10:00' },
+				{ start: '2014-12-11T16:00', end: '2014-12-12T00:00' },
+				// fri
+				{ start: '2014-12-12T00:00', end: '2014-12-12T10:00' },
+				{ start: '2014-12-12T16:00', end: '2014-12-13T00:00' },
+				// sat
+				{ start: '2014-12-13T00:00', end: '2014-12-14T00:00' }
+			])).toBe(true);
+		});
 	});
 
 


### PR DESCRIPTION
Hello,

I'm using businessHours setting.
And I want to add irregular (non-periodic) non business days (e.g. public holidays) and business days (e.g. extraordinary opening).
But currently FullCalendar's businessHours setting allows only dow.

This pull request adds a filter callback which enable adding/removing elements to/from instantiated events of businessHours.

Thanks.