### PR TITLE
bower: bump moment to 2.20.1, which includes Chinese fixes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   "copyright": "2017 Adam Shaw",
   "dependencies": {
     "jquery": "2 - 3",
-    "moment": "^2.9.0"
+    "moment": "^2.20.1"
   },
   "main": [
     "dist/fullcalendar.js",


### PR DESCRIPTION
Motivation: Handling of Chinese dates are broken in Nextcloud (https://github.com/nextcloud/calendar/issues/534). It turns out that locale handling was broken in older moment.js versions. This is fixed in https://github.com/moment/moment/pull/3952 and included in moment.js 2.20.0.