### PR TITLE
Add aria-label to toolbar icon buttons

### DIFF
--- a/src/Toolbar.ts
+++ b/src/Toolbar.ts
@@ -80,6 +80,7 @@ export default class Toolbar {
           let buttonInnerHtml
           let buttonClasses
           let buttonEl
+          let buttonAriaAttr
 
           if (buttonName === 'title') {
             groupChildren = groupChildren.add($('<h2>&nbsp;</h2>')) // we always want it to take up height
@@ -123,12 +124,15 @@ export default class Toolbar {
 
               if (buttonText) {
                 buttonInnerHtml = htmlEscape(buttonText)
+                buttonAriaAttr = ''
               } else if (buttonIcon) {
                 buttonInnerHtml = "<span class='" + buttonIcon + "'></span>"
+                buttonAriaAttr = '" aria-label="' + buttonName
               }
 
               buttonEl = $( // type="button" so that it doesn't submit a form
-                '<button type="button" class="' + buttonClasses.join(' ') + '">' +
+                '<button type="button" class="' + buttonClasses.join(' ') +
+                  buttonAriaAttr + '">' +
                   buttonInnerHtml +
                 '</button>'
                 )


### PR DESCRIPTION
Very initial work on addressing issues brought forward in #2536. Began by trying to address ARIA labeling of previous/next buttons which only use icons.

**Open Questions**
1. Any advice on the approach or specific implementation details would be appreciated.
2. Are tests desired to check for the attribute? How to test a11y?
2. It doesn't seem there is currently appropriate text for these buttons, which for English would be "Previous" and "Next" and would be needed in all other locales as well, so what is the appropriate way to acquire this text? Can we start with a few common locales?
3. What else is needed to make this addition viable?

Any feedback would be appreciated, thanks!