### PR TITLE
Allow the event to define if the end time should be shown

### DIFF
--- a/demos/agenda-views.html
+++ b/demos/agenda-views.html
@@ -72,6 +72,12 @@
           start: '2017-12-13T07:00:00'
         },
         {
+            title: 'No end time shown',
+            start: '2017-12-15T07:00:00',
+            end: '2017-12-16T12:30:00',
+            displayEventEnd: false
+        },
+        {
           title: 'Click for Google',
           url: 'http://google.com/',
           start: '2017-12-28'

--- a/src/agenda/TimeGridEventRenderer.ts
+++ b/src/agenda/TimeGridEventRenderer.ts
@@ -84,7 +84,7 @@ export default class TimeGridEventRenderer extends EventRenderer {
       if (seg.isStart || seg.isEnd) {
         let zonedStart = calendar.msToMoment(seg.startMs)
         let zonedEnd = calendar.msToMoment(seg.endMs)
-        timeText = this._getTimeText(zonedStart, zonedEnd, isAllDay)
+        timeText = this._getTimeText(zonedStart, zonedEnd, isAllDay, null, eventDef.miscProps.displayEventEnd)
         fullTimeText = this._getTimeText(zonedStart, zonedEnd, isAllDay, 'LT')
         startTimeText = this._getTimeText(zonedStart, zonedEnd, isAllDay, null, false) // displayEnd=false
       }

--- a/src/component/renderers/EventRenderer.ts
+++ b/src/component/renderers/EventRenderer.ts
@@ -268,6 +268,9 @@ export default class EventRenderer {
   // If not specified, formatStr will default to the eventTimeFormat setting,
   // and displayEnd will default to the displayEventEnd setting.
   getTimeText(eventFootprint, formatStr?, displayEnd?) {
+    if (eventFootprint.eventDef.miscProps.displayEventEnd !== 'undefined') {
+      displayEnd = eventFootprint.eventDef.miscProps.displayEventEnd;
+    }
     return this._getTimeText(
       eventFootprint.eventInstance.dateProfile.start,
       eventFootprint.eventInstance.dateProfile.end,


### PR DESCRIPTION
Support a new property for an event to define if the event end time should be shown or not.