### PR TITLE
Expose missing OptionsInput type and fix some jquery hooks types

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -7,9 +7,10 @@ export const version = '<%= version %>'
 export const internalApiVersion = 12
 
 export {
-  EventObjectInput,
   BusinessHoursInput,
-  EventOptionsBase
+  EventObjectInput,
+  EventOptionsBase,
+  OptionsInput
 } from './types/input-types'
 
 export {

--- a/src/types/jquery-hooks.ts
+++ b/src/types/jquery-hooks.ts
@@ -17,7 +17,7 @@ declare global {
     fullCalendar(method: 'destroy'): JQuery
     fullCalendar(method: 'option', name: string | object, value?: any): any
     fullCalendar(method: 'isValidViewType', viewType: string): boolean
-    fullCalendar(method: 'changeView', viewName: string, dateOrRange: RangeInput | MomentInput): JQuery
+    fullCalendar(method: 'changeView', viewName: string, dateOrRange?: RangeInput | MomentInput): JQuery
     fullCalendar(method: 'zoomTo', newDate: moment.Moment, viewType?: string): JQuery
     fullCalendar(method: 'prev'): JQuery
     fullCalendar(method: 'next'): JQuery
@@ -36,7 +36,7 @@ declare global {
     fullCalendar(method: 'refetchEvents'): JQuery
     fullCalendar(method: 'renderEvents', eventInputs: EventObjectInput[], isSticky?: boolean): JQuery
     fullCalendar(method: 'renderEvent', eventInput: EventObjectInput, isSticky?: boolean): JQuery
-    fullCalendar(method: 'removeEvents', legacyQuery: any): JQuery
+    fullCalendar(method: 'removeEvents', legacyQuery?: any): JQuery
     fullCalendar(method: 'clientEvents', legacyQuery: any): any
     fullCalendar(method: 'updateEvents', eventPropsArray: EventObjectInput[]): JQuery
     fullCalendar(method: 'updateEvent', eventProps: EventObjectInput): JQuery


### PR DESCRIPTION
Exposed `OptionsInput` for the ability to type externally created fullcalendar options.

Fixed two optional parameters in `jquery-hooks` based on:

- [https://fullcalendar.io/docs/event_data/removeEvents/](https://fullcalendar.io/docs/event_data/removeEvents/)
- [https://fullcalendar.io/docs/views/changeView/](https://fullcalendar.io/docs/views/changeView/)