### PR TITLE
Corrected the swedish week header.

### DIFF
--- a/locale/sv.js
+++ b/locale/sv.js
@@ -16,7 +16,7 @@ FullCalendar.datepickerLocale('sv', 'sv', {
   dayNamesShort: [ "Sön","Mån","Tis","Ons","Tor","Fre","Lör" ],
   dayNames: [ "Söndag","Måndag","Tisdag","Onsdag","Torsdag","Fredag","Lördag" ],
   dayNamesMin: [ "Sö","Må","Ti","On","To","Fr","Lö" ],
-  weekHeader: "Ve",
+  weekHeader: "v. ",
   dateFormat: "yy-mm-dd",
   firstDay: 1,
   isRTL: false,


### PR DESCRIPTION
The previous abbreviation "Ve" is not correct and does not follow any standards. I've changed the abbreviation to `v. ` including a trailing whitespace which becomes `v. 9`. This is the correct way to shorten "week" in swedish.

**Source:**
[https://sv.wiktionary.org/wiki/v.](https://sv.wiktionary.org/wiki/v.)

`2. förkortning för vecka` which translates to `2. abbreviation for week`.