### PR TITLE
Issue #4079 forceEventDuration takes wrong duration when switchingbetween all day and timed event

### DIFF
--- a/src/models/event/EventDefDateMutation.ts
+++ b/src/models/event/EventDefDateMutation.ts
@@ -125,7 +125,7 @@ export default class EventDefDateMutation {
 
     // TODO: okay to access calendar option?
     if (!end && calendar.opt('forceEventDuration')) {
-      end = calendar.getDefaultEventEnd(eventDateProfile.isAllDay(), start)
+      end = calendar.getDefaultEventEnd(!start.hasTime(), start)
     }
 
     return new EventDateProfile(start, end, calendar)


### PR DESCRIPTION
When forceEventDuration is set, we expect defaultTimedEventDuration to be used for timed events and defaultAllDayEventDuration for all day events.

On the agendaWeek view, if you drag a timed event to the all day section it takes the defaultTimedEventDuration because it check the allDay flag on the source "DateProfile".

When dragging from allDay section to to the timed grid. It takes the defaultAllDayEventDuration which is also wrong.

see EventDefDateMutation.prototype.buildNewDateProfile

To reproduce, use the code below and drag the event in the all day section. You will see in the console that the end time will be 2018-03-06T00:30. It should be 2018-03-07 00:00:00.

If you drag back the event in the grid, it will have a duration of 1 day where it should be 30 minutes.

https://codepen.io/etremblay/pen/dmPYyJ