### PR TITLE
GCal: pass extendedProperties along

### DIFF
--- a/plugins/gcal/GcalEventSource.ts
+++ b/plugins/gcal/GcalEventSource.ts
@@ -102,10 +102,10 @@ export default class GcalEventSource extends EventSource {
     if (url && gcalTimezone) {
       url = injectQsComponent(url, 'ctz=' + gcalTimezone)
     }
-    
-    let meta_data = {};
+
+    let metaData = {}
     if (typeof item.extendedProperties === 'object' && typeof item.extendedProperties.shared === 'object') {
-      meta_data = item.extendedProperties.shared;
+      metaData = item.extendedProperties.shared
     }
 
     return {
@@ -116,7 +116,7 @@ export default class GcalEventSource extends EventSource {
       url: url,
       location: item.location,
       description: item.description,
-      meta_data: meta_data
+      metaData: metaData
     }
   }
 

--- a/plugins/gcal/GcalEventSource.ts
+++ b/plugins/gcal/GcalEventSource.ts
@@ -102,6 +102,11 @@ export default class GcalEventSource extends EventSource {
     if (url && gcalTimezone) {
       url = injectQsComponent(url, 'ctz=' + gcalTimezone)
     }
+    
+    let meta_data = {};
+    if (typeof item.extendedProperties === 'object' && typeof item.extendedProperties.shared === 'object') {
+      meta_data = item.extendedProperties.shared;
+    }
 
     return {
       id: item.id,
@@ -111,7 +116,7 @@ export default class GcalEventSource extends EventSource {
       url: url,
       location: item.location,
       description: item.description,
-      meta_data: item.extendedProperties.shared
+      meta_data: meta_data
     }
   }
 


### PR DESCRIPTION
Implements feature request #4122 

# About Extended properties
Extended properties allow you to set some meta data on google calendar events. They are not visible but can be set through the Google API. This is often used for meta data, like a tag or category for your event. 

# Problem
It would be super nice to attach a class depending on an extended property, or influence how an event is rendered. However, the gcal plugin doesn't pass the properties along to the fullcalendar event.

# Solution
Just pass along the shared extende properties to the fullcalendar event. The fix is small yet does the trick.