### PR TITLE
Added buttonText year translation for the german files.

### DIFF
--- a/locale/de-at.js
+++ b/locale/de-at.js
@@ -26,7 +26,7 @@ FullCalendar.datepickerLocale('de-at', 'de', {
 
 FullCalendar.locale("de-at", {
   buttonText: {
-	year: "Jahr",
+	  year: "Jahr",
     month: "Monat",
     week: "Woche",
     day: "Tag",

--- a/locale/de-at.js
+++ b/locale/de-at.js
@@ -26,6 +26,7 @@ FullCalendar.datepickerLocale('de-at', 'de', {
 
 FullCalendar.locale("de-at", {
   buttonText: {
+	year: "Jahr",
     month: "Monat",
     week: "Woche",
     day: "Tag",

--- a/locale/de-ch.js
+++ b/locale/de-ch.js
@@ -26,6 +26,7 @@ FullCalendar.datepickerLocale('de-ch', 'de', {
 
 FullCalendar.locale("de-ch", {
   buttonText: {
+	year: "Jahr",
     month: "Monat",
     week: "Woche",
     day: "Tag",

--- a/locale/de-ch.js
+++ b/locale/de-ch.js
@@ -26,7 +26,7 @@ FullCalendar.datepickerLocale('de-ch', 'de', {
 
 FullCalendar.locale("de-ch", {
   buttonText: {
-	year: "Jahr",
+	  year: "Jahr",
     month: "Monat",
     week: "Woche",
     day: "Tag",

--- a/locale/de.js
+++ b/locale/de.js
@@ -26,6 +26,7 @@ FullCalendar.datepickerLocale('de', 'de', {
 
 FullCalendar.locale("de", {
   buttonText: {
+	year: "Jahr",
     month: "Monat",
     week: "Woche",
     day: "Tag",

--- a/locale/de.js
+++ b/locale/de.js
@@ -26,7 +26,7 @@ FullCalendar.datepickerLocale('de', 'de', {
 
 FullCalendar.locale("de", {
   buttonText: {
-	year: "Jahr",
+	  year: "Jahr",
     month: "Monat",
     week: "Woche",
     day: "Tag",


### PR DESCRIPTION
See https://github.com/fullcalendar/fullcalendar/issues/4193.

But there are still lots of language files without the year-buttonText translation.