### PR TITLE
Added typescript definition for selectAllow

### DIFF
--- a/src/types/input-types.ts
+++ b/src/types/input-types.ts
@@ -116,6 +116,12 @@ export interface DropInfo {
   end: moment.Moment
 }
 
+export interface SelectInfo {
+  start: moment.Moment
+  end: moment.Moment
+  resourceId?: string
+}
+
 export interface OptionsInputBase {
   header?: boolean | ToolbarInput
   footer?: boolean | ToolbarInput
@@ -191,6 +197,7 @@ export interface OptionsInputBase {
   unselectCancel?: string
   selectOverlap?: boolean | ((event: EventObjectInput) => boolean)
   selectConstraint?: ConstraintInput
+  selectAllow?: ((selectInfo: SelectInfo) => boolean)
   events?: EventSourceInput
   eventSources?: EventSourceInput[]
   allDayDefault?: boolean


### PR DESCRIPTION
Typescript definitions for `selectAllow` (https://fullcalendar.io/docs/selectAllow) was missing.