### PR TITLE
Issue #4370: Wrong date formatting in agendaWeek with German locale

### DIFF
--- a/locale/de.js
+++ b/locale/de.js
@@ -35,5 +35,6 @@ FullCalendar.locale("de", {
   eventLimitText: function(n) {
     return "+ weitere " + n;
   },
-  noEventsMessage: "Keine Ereignisse anzuzeigen"
+  noEventsMessage: "Keine Ereignisse anzuzeigen",
+  dayOfMonthFormat: 'ddd DD.MM.'
 });


### PR DESCRIPTION
This commit fixed the issue #4370:
With "lang" set to "de", the heading of agendaweek is missing a dot after the month number
Expected output for 2018-11-06:
"Di. 06.11."
Actual:
"Di. 06.11"

See this MCVE: http://jsfiddle.net/41sc3ed5/3