### PR TITLE
Add support to ctrl+click multi dates on Windows

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -296,7 +296,10 @@ function getCssFloat(el, prop) {
 
 // Returns a boolean whether this was a left mouse click and no ctrl key (which means right click on Mac)
 export function isPrimaryMouseButton(ev) {
-  return ev.which === 1 && !ev.ctrlKey
+  if (window.navigator.userAgent.includes("Windows"))
+    return ev.which === 1
+  else
+    return ev.which === 1 && !ev.ctrlKey
 }
 
 


### PR DESCRIPTION
This checks whether the platform is windows and if so adds support to ctrl click and select multiple days on the calendar.