### PR TITLE
adding viewSkeletonRender function to OptionsInputBase interface

### DIFF
--- a/src/core/types/input-types.ts
+++ b/src/core/types/input-types.ts
@@ -201,6 +201,7 @@ export interface OptionsInputBase {
   drop?(arg: { date: Date, dateStr: string, allDay: boolean, draggedEl: HTMLElement, jsEvent: MouseEvent, view: View }): void
   eventReceive?(arg: { event: EventApi, draggedEl: HTMLElement, view: View }): void
   eventLeave?(arg: { draggedEl: HTMLElement, event: EventApi, view: View }): void
+  viewSkeletonRender?(arg: { el: HTMLElement, view: View }): void
 }
 
 export interface ViewOptionsInput extends OptionsInputBase {


### PR DESCRIPTION
As instructed on a fullcalendar/scheduler issue (https://github.com/fullcalendar/fullcalendar-scheduler/issues/508) I'm using `viewSkeletonRender` function to replace the Resource Header element after the initial render.

This breaks the TypeScript build, because `viewSkeletonRender` is not on the `OptionsInput` interface.

This PR just adds `viewSkeletonRender` to the `OptionsInputBase` interface.