### PR TITLE
Fix link to Google Style Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,5 +118,5 @@ If you have edited code (including **tests** and **translations**) and would lik
 [git]: http://git-scm.com/
 [node]: http://nodejs.org/
 [sass]: https://sass-lang.com/install
-[Google JavaScript Style Guide]: http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml
+[Google JavaScript Style Guide]: https://google.github.io/styleguide/jsguide.html
 [Automated Test Readme]: https://github.com/fullcalendar/fullcalendar/wiki/Automated-Tests


### PR DESCRIPTION
The following link to the Google Style Guide is not working anymore:
http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml

The new link is:
https://google.github.io/styleguide/jsguide.html