### PR TITLE
Go back to Node 11 until Travis has Node 12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 
 language: node_js
 node_js:
-  - node # implies latest version
+  - "11" # restore back to "node" (without quotes) when Travis is compatible with Node 12
 
 cache:
   directories:


### PR DESCRIPTION
All builds are failing because of a problem with Travis's support of Node 12 yet. https://discourse.elm-lang.org/t/travis-build-failing-and-other-occassions/3546

This PR switches the Travis build config from using the latest Node to instead stick to Node 11 so that builds will work again.

When Travis builds on Node 12 are working, this change should be reverted.

Fixes #4649