### PR TITLE
Type-safe event handlers (and fix OptionsInput event handler typings)

### DIFF
--- a/src/core/component/DateComponent.ts
+++ b/src/core/component/DateComponent.ts
@@ -10,6 +10,8 @@ import EventApi from '../api/EventApi'
 import FgEventRenderer from './renderers/FgEventRenderer'
 import FillRenderer from './renderers/FillRenderer'
 import { EventInteractionState } from '../interactions/event-interaction-state'
+import View from '../View'
+import { EventHandlerName, EventHandlerArgs } from '../types/input-types'
 
 export type DateComponentHash = { [uid: string]: DateComponent<any> }
 
@@ -153,21 +155,21 @@ export default class DateComponent<PropsType> extends Component<PropsType> {
   // TODO: move to Calendar
 
 
-  publiclyTrigger(name, args) {
+  publiclyTrigger<T extends EventHandlerName>(name: T, args?: EventHandlerArgs<T>) {
     let calendar = this.calendar
 
     return calendar.publiclyTrigger(name, args)
   }
 
 
-  publiclyTriggerAfterSizing(name, args) {
+  publiclyTriggerAfterSizing<T extends EventHandlerName>(name: T, args: EventHandlerArgs<T>) {
     let calendar = this.calendar
 
     return calendar.publiclyTriggerAfterSizing(name, args)
   }
 
 
-  hasPublicHandlers(name) {
+  hasPublicHandlers<T extends EventHandlerName>(name: T) {
     let calendar = this.calendar
 
     return calendar.hasPublicHandlers(name)
@@ -191,7 +193,7 @@ export default class DateComponent<PropsType> extends Component<PropsType> {
             isStart: seg.isStart,
             isEnd: seg.isEnd,
             el: seg.el,
-            view: this // ?
+            view: this as unknown as View // safe to cast because this method is only called on context.view
           }
         ])
       }
@@ -221,7 +223,7 @@ export default class DateComponent<PropsType> extends Component<PropsType> {
             ),
             isMirror: isMirrors,
             el: seg.el,
-            view: this // ?
+            view: this as unknown as View // safe to cast because this method is only called on context.view
           }
         ])
       }

--- a/src/core/component/event-rendering.ts
+++ b/src/core/component/event-rendering.ts
@@ -117,7 +117,7 @@ export function hasBgRendering(def: EventDef) {
   return def.rendering === 'background' || def.rendering === 'inverse-background'
 }
 
-export function filterSegsViaEls(view: View, segs: Seg[], isMirror) {
+export function filterSegsViaEls(view: View, segs: Seg[], isMirror: boolean) {
 
   if (view.hasPublicHandlers('eventRender')) {
     segs = segs.filter(function(seg) {

--- a/src/core/interactions/EventClicking.ts
+++ b/src/core/interactions/EventClicking.ts
@@ -43,7 +43,7 @@ export default class EventClicking extends Interaction {
             seg.eventRange.def,
             seg.eventRange.instance
           ),
-          jsEvent: ev,
+          jsEvent: ev as MouseEvent, // Is this always a mouse event? See #4655
           view: component.view
         }
       ])

--- a/src/core/interactions/EventHovering.ts
+++ b/src/core/interactions/EventHovering.ts
@@ -54,7 +54,7 @@ export default class EventHovering extends Interaction {
     }
   }
 
-  triggerEvent(publicEvName: string, ev: Event | null, segEl: HTMLElement) {
+  triggerEvent(publicEvName: 'eventMouseEnter' | 'eventMouseLeave', ev: Event | null, segEl: HTMLElement) {
     let { component } = this
     let seg = getElSeg(segEl)!
 
@@ -67,7 +67,7 @@ export default class EventHovering extends Interaction {
             seg.eventRange.def,
             seg.eventRange.instance
           ),
-          jsEvent: ev,
+          jsEvent: ev as MouseEvent, // Is this always a mouse event? See #4655
           view: component.view
         }
       ])

--- a/src/core/interactions/event-dragging.ts
+++ b/src/core/interactions/event-dragging.ts
@@ -1,6 +1,7 @@
 import Calendar from '../Calendar'
 import { EventMutation } from '../structs/event-mutation'
 import { Hit } from './hit'
+import { EventHandlerArg } from '../types/input-types'
 
 export type eventDragMutationMassager = (mutation: EventMutation, hit0: Hit, hit1: Hit) => void
-export type EventDropTransformers = (mutation: EventMutation, calendar: Calendar) => void
+export type EventDropTransformers = (mutation: EventMutation, calendar: Calendar) => Partial<EventHandlerArg<'eventDrop'>>

--- a/src/core/types/input-types.ts
+++ b/src/core/types/input-types.ts
@@ -70,6 +70,23 @@ export interface DropInfo {
   end: Date
 }
 
+// TODO: refactor OptionsInputBase to split out event handlers into a separate interface,
+// which will enable replacing the static list of event handlers below with a simpler
+// `keyof OptionsInputBaseEventHandlers`
+export type EventHandlerName =
+  '_init' | 'selectAllow' | 'eventAllow' | 'eventDataTransform' | 'datesRender' |
+  'datesDestroy' | 'dayRender' | 'windowResize' | 'dateClick' | 'eventClick' |
+  'eventMouseEnter' | 'eventMouseLeave' | 'select' | 'unselect' | 'loading' |
+  'eventRender' | 'eventPositioned' | '_eventsPositioned' | 'eventDestroy' |
+  'eventDragStart' | 'eventDragStop' | 'eventDrop' | '_destroyed' | 'drop' |
+  'eventResizeStart' | 'eventResizeStop' | 'eventResize' | 'eventReceive' |
+  'eventLeave' | 'viewSkeletonRender' | 'viewSkeletonDestroy' | '_noEventDrop' |
+  '_noEventResize' | 'eventLimitClick'
+
+export type EventHandlerArgs<T extends EventHandlerName> =
+  Parameters<Extract<OptionsInput[T], (...args: any[]) => any>>
+export type EventHandlerArg<T extends EventHandlerName> = EventHandlerArgs<T>[0]
+
 export interface OptionsInputBase {
   header?: boolean | ToolbarInput
   footer?: boolean | ToolbarInput
@@ -93,7 +110,8 @@ export interface OptionsInputBase {
   handleWindowResize?: boolean
   windowResizeDelay?: number
   eventLimit?: boolean | number
-  eventLimitClick?: 'popover' | 'week' | 'day' | string | ((cellinfo: CellInfo, jsevent: Event) => void)
+  eventLimitClick?: 'popover' | 'week' | 'day' | 'timeGridWeek' | 'timeGridDay' | string |
+    ((arg: { date: Date, allDay: boolean, dayEl: HTMLElement, moreEl: HTMLElement, segs: any[], hiddenSegs: any[], jsEvent: MouseEvent, view: View }) => void),
   timeZone?: string | boolean
   now?: DateInput | (() => DateInput)
   defaultView?: string
@@ -178,31 +196,34 @@ export interface OptionsInputBase {
   timeGridEventMinHeight?: number
   datesRender?(arg: { view: View, el: HTMLElement }): void
   datesDestroy?(arg: { view: View, el: HTMLElement }): void
-  dayRender?(arg: { view: View, date: Date, allDay: boolean, el: HTMLElement }): void
+  dayRender?(arg: { view: View, date: Date, allDay?: boolean, el: HTMLElement }): void
   windowResize?(view: View): void
-  dateClick?(arg: { date: Date, dateStr: string, allDay: boolean, resource: any, dayEl: HTMLElement, jsEvent: MouseEvent, view: View }): void // resource for Scheduler
+  dateClick?(arg: { date: Date, dateStr: string, allDay: boolean, resource?: any, dayEl: HTMLElement, jsEvent: MouseEvent, view: View }): void // resource for Scheduler
   eventClick?(arg: { el: HTMLElement, event: EventApi, jsEvent: MouseEvent, view: View }): boolean | void
   eventMouseEnter?(arg: { el: HTMLElement, event: EventApi, jsEvent: MouseEvent, view: View }): void
   eventMouseLeave?(arg: { el: HTMLElement, event: EventApi, jsEvent: MouseEvent, view: View }): void
-  select?(arg: { start: Date, end: Date, startStr: string, endStr: string, allDay: boolean, resource: any, jsEvent: MouseEvent, view: View }): void // resource for Scheduler
+  select?(arg: { start: Date, end: Date, startStr: string, endStr: string, allDay: boolean, resource?: any, jsEvent: MouseEvent, view: View }): void // resource for Scheduler
   unselect?(arg: { view: View, jsEvent: Event }): void
-  loading?(isLoading: boolean, view: View): void
-  eventRender?(arg: { event: EventApi, el: HTMLElement, view: View }): void
-  eventPositioned?(arg: { event: EventApi, el: HTMLElement, view: View }): void
+  loading?(isLoading: boolean): void
+  eventRender?(arg: { isMirror: boolean, isStart: boolean, isEnd: boolean, event: EventApi, el: HTMLElement, view: View }): void
+  eventPositioned?(arg: { isMirror: boolean, isStart: boolean, isEnd: boolean, event: EventApi, el: HTMLElement, view: View }): void
   _eventsPositioned?(arg: { view: View }): void
-  eventDestroy?(arg: { event: EventApi, el: HTMLElement, view: View }): void
+  eventDestroy?(arg: { isMirror: boolean, event: EventApi, el: HTMLElement, view: View }): void
   eventDragStart?(arg: { event: EventApi, el: HTMLElement, jsEvent: MouseEvent, view: View }): void
   eventDragStop?(arg: { event: EventApi, el: HTMLElement, jsEvent: MouseEvent, view: View }): void
-  eventDrop?(arg: { el: HTMLElement, event: EventApi, delta: Duration, revert: () => void, jsEvent: Event, view: View }): void
+  eventDrop?(arg: { el: HTMLElement, event: EventApi, oldEvent: EventApi, delta: Duration, revert: () => void, jsEvent: Event, view: View }): void
   eventResizeStart?(arg: { el: HTMLElement, event: EventApi, jsEvent: MouseEvent, view: View }): void
   eventResizeStop?(arg: { el: HTMLElement, event: EventApi, jsEvent: MouseEvent, view: View }): void
-  eventResize?(arg: { el: HTMLElement, event: EventApi, delta: Duration, revert: () => void, jsEvent: Event, view: View }): void
+  eventResize?(arg: { el: HTMLElement, startDelta: Duration, endDelta: Duration, prevEvent: EventApi, event: EventApi, revert: () => void, jsEvent: Event, view: View }): void
   drop?(arg: { date: Date, dateStr: string, allDay: boolean, draggedEl: HTMLElement, jsEvent: MouseEvent, view: View }): void
   eventReceive?(arg: { event: EventApi, draggedEl: HTMLElement, view: View }): void
   eventLeave?(arg: { draggedEl: HTMLElement, event: EventApi, view: View }): void
   viewSkeletonRender?(arg: { el: HTMLElement, view: View }): void
   viewSkeletonDestroy?(arg: { el: HTMLElement, view: View }): void
   _destroyed?(): void
+  _init?(): void
+  _noEventDrop?(): void
+  _noEventResize?(): void
 }
 
 export interface ViewOptionsInput extends OptionsInputBase {

--- a/src/interaction/interactions-external/ExternalElementDragging.ts
+++ b/src/interaction/interactions-external/ExternalElementDragging.ts
@@ -130,12 +130,12 @@ export default class ExternalElementDragging {
       let finalHit = this.hitDragging.finalHit!
       let finalView = finalHit.component.view
       let dragMeta = this.dragMeta!
-      let arg = receivingCalendar.buildDatePointApi(finalHit.dateSpan) as ExternalDropApi
-
-      arg.draggedEl = pev.subjectEl as HTMLElement
-      arg.jsEvent = pev.origEvent
-      arg.view = finalView
-
+      let arg = {
+        ...receivingCalendar.buildDatePointApi(finalHit.dateSpan),
+        draggedEl: pev.subjectEl as HTMLElement,
+        jsEvent: pev.origEvent as MouseEvent, // Is this always a mouse event? See #4655
+        view: finalView
+      }
       receivingCalendar.publiclyTrigger('drop', [ arg ])
 
       if (dragMeta.create) {
@@ -154,7 +154,7 @@ export default class ExternalElementDragging {
         // signal that an external event landed
         receivingCalendar.publiclyTrigger('eventReceive', [
           {
-            draggedEl: pev.subjectEl,
+            draggedEl: pev.subjectEl as HTMLElement,
             event: new EventApi(
               receivingCalendar,
               droppableEvent.def,

--- a/src/interaction/interactions/EventResizing.ts
+++ b/src/interaction/interactions/EventResizing.ts
@@ -80,7 +80,7 @@ export default class EventDragging extends Interaction {
       {
         el: this.draggingSeg.el,
         event: new EventApi(calendar, eventRange.def, eventRange.instance),
-        jsEvent: ev.origEvent,
+        jsEvent: ev.origEvent as MouseEvent, // Is this always a mouse event? See #4655
         view: this.component.view
       }
     ])
@@ -163,7 +163,7 @@ export default class EventDragging extends Interaction {
       {
         el: this.draggingSeg.el,
         event: eventApi,
-        jsEvent: ev.origEvent,
+        jsEvent: ev.origEvent as MouseEvent, // Is this always a mouse event? See #4655
         view
       }
     ])


### PR DESCRIPTION
This PR prevents `OptionsInput` event-handler typings from getting out-of-sync with code that triggers events.  It does this by adding type safety to event-triggering methods in FullCalendar.  If an event is triggered with the wrong parameter type or event name, a compiler error will result.  This should prevent handler-typing problems from happening in the future, as well as making it easy to find event-handler typing issues in current code.  Fixes #4656. Fixes #4654.

Because types are inferred based on the event name (e.g. `'drop'` or `'eventMouseLeave'`), no code changes are needed for existing or future event-triggering code, except to fix compiler errors caused by passing the wrong types or by mistakes in type declarations. 

Speaking of "_mistakes in type declarations_", this PR also fixes the type declaration problems in #4654 as well as any compiler errors exposed by adding type checking to event handlers.

This PR does not contain any runtime breaking changes. Furthermore, almost all changes in this PR are limited to type annotations and casts, which have no runtime code impact. The only exceptions to this "no runtime code impact" rule are refactoring a few object initializers where it wasn't practical or type-safe to fix type issues with casts alone.

Even at compile time, clients should not encounter new compile errors as a result of this PR because almost all changes to `OptionsInput` are widening changes, not narrowing. The only exceptions are clients expecting event properties that are never actually provided (`delta` on `eventResize`, `cellinfo` on `eventLimitClick`, or `view` on  `isLoading`).  Given that client code using these props is already broken, it seems better to emit compiler errors instead of letting those clients continue compiling code that will never work at runtime.

This PR has two parts: 

1. **Type-safe event triggering**
    * `Calendar.publiclyTrigger()` will now cause a compiler error if called with the wrong parameter type(s)
    * Event names are also checked, so a typo in the event name (e.g. `droppp`) will also cause a compiler error. 
    * Other related methods (e.g. `publiclyTriggerAfterSizing`, `hasPublicHandlers`, and corresponding methods inside DateComponent.ts) are now type-safe too.
    * As noted above, no code changes to triggering code are required if the triggering code is already using correct types.
    * When assembling event parameters in multiple steps, you can optionally use the new `EventHandlerArg<T>` type to catch type errors sooner instead of waiting until events are triggered.  Example:
```typescript
export type EventDropTransformers = (
  mutation: EventMutation, 
  calendar: Calendar
) => Partial<EventHandlerArg<'eventDrop'>>
```

2. **Fixing compiler errors**  As expected from #4654, after type checking was added to event triggering there were lots of compiler errors caused by missing and incorrect typings. This PR fixes these errors as follows: 
    * Adds 20+ properties that are missing from typings, e.g. `oldEvent: EventApi` on the `eventDrop` event.
    * Adds typings for `_init`, `_noEventDrop`, and `_noEventResize` events
    * Removes three event properties that are not used anywhere in FullCalendar.  Note that these are NOT runtime breaking changes because the props shown in typings were always missing at runtime.
       * the `delta` prop on the `eventResize` event (the actual props used are `startDelta` and `endDelta`) https://github.com/fullcalendar/fullcalendar/blob/f827f233581338ceb9723eabb7f895731498fd5b/src/interaction/interactions/EventResizing.ts#L177-L197
       * the `cellinfo` prop on the `eventLimitClick` event (the actual props are expanded individually into the arg, not bundled into a `cellInfo` prop) https://github.com/fullcalendar/fullcalendar/blob/f827f233581338ceb9723eabb7f895731498fd5b/src/daygrid/DayGrid.ts#L728-L739
       * the `view` prop on the `isLoading` event, which is not used in the only code that triggers this event: https://github.com/fullcalendar/fullcalendar/blob/f827f233581338ceb9723eabb7f895731498fd5b/src/core/Calendar.ts#L306-L310
    * Adds type casts from `EventTarget` to `HTMLElement`, which is already done in many other places in FullCalendar event handlers. 
    * Adds type casts in `DateComponent.triggerRenderedSegs` and `DateComponent.triggerWillRemoveSegs` from `DateComponent` to `View`, which is safe because these methods are only called through the `context.view` property which is a `View`.
![image](https://user-images.githubusercontent.com/277214/56869688-66235000-69b8-11e9-8c87-2f0d2de2af19.png)
   * Adds type casts in `EventDragging.handleDragEnd()` for `finalHit.component as View`.  It seems likely that this runtime code is wrong (not just the typing) and should be `finalHit.component.view`. But I wanted to avoid scope creep and to keep breaking changes out of this PR, so I left the current behavior as-is and added comments pointing to #4644 which tracks this potential problem.
   * Adds type casts for underlying JS events, usually from `UIEvent` to `MouseEvent`.  I'm not sure that all these are actually `MouseEvent` instances (e.g. could they be triggered by touch events, or simulated without all the MouseEvent properties?) but I didn't want to introduce breaking changes in this PR. So I marked these casts with warning comments and filed #4655 to investigate whether these casts are always valid.
    * Refactors 5 places where events are assembled from multiple statements.  It wasn't possible (especially given `UIEvent` vs. `MouseEvent` mismatches noted above) to make these multi-statement initializations type-safe while also keeping code readable and DRY. So I refactored these initializations to use the same data but combined multiple statements into a single type-safe initializer. Note that these refactors are the only non-type-annotation changes in this PR. Example: 
```typescript
      // before
      let arg = receivingCalendar.buildDatePointApi(finalHit.dateSpan) as ExternalDropApi

      arg.draggedEl = pev.subjectEl as HTMLElement
      arg.jsEvent = pev.origEvent
      arg.view = finalView

      // after
      let arg = {
        ...receivingCalendar.buildDatePointApi(finalHit.dateSpan),
        draggedEl: pev.subjectEl as HTMLElement,
        jsEvent: pev.origEvent as MouseEvent,
        view: finalView
      }
```
