### PR TITLE
Updated sass script

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "tsc-watch": "tsc --watch --sourceMap",
     "rollup": "rollup -c --environment BUILD:production",
     "rollup-watch": "sleep 5 && rollup -c --environment BUILD:development --watch",
-    "sass": "sass --update --sourcemap=none $(bin/sass-args.js)",
+    "sass": "sass --update --no-source-map $(bin/sass-args.js)",
     "sass-watch": "sass --watch $(bin/sass-args.js)",
     "test": "karma start karma.config.js --auto-watch",
     "test-single": "karma start karma.config.js --browsers ChromeHeadless_custom --single-run",


### PR DESCRIPTION
We are having the same problem as [ColorlibHQ Issue #678](https://github.com/ColorlibHQ/gentelella/issues/687).

```npm run sass``` is failing because we are still using the ```--sourcemap``` option.

This PR is a simple update to using ```--no-sourcemap``` instead of ```--sourcemap=none```

Please see [sass-lang's documentation](https://sass-lang.com/documentation/cli/dart-sass#no-source-map) for this option if you have any questions.