### PR TITLE
Fix typo in Danish locale file

### DIFF
--- a/locales/da.js
+++ b/locales/da.js
@@ -8,7 +8,7 @@ export default {
   buttonText: {
     prev: "Forrige",
     next: "Næste",
-    today: "Idag",
+    today: "I dag",
     month: "Måned",
     week: "Uge",
     day: "Dag",


### PR DESCRIPTION
The correct spelling is two words: https://ordnet.dk/ddo/ordbog?query=i%20dag