### PR TITLE
fix sourcemaps + publish /src to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "native-promise-only": "^0.8.1",
     "rollup": "1.8.0",
     "rollup-plugin-commonjs": "^9.0.0",
+    "rollup-plugin-copy-glob": "^0.3.0",
     "rollup-plugin-multi-entry": "^2.1.0",
     "rollup-plugin-node-resolve": "4.0.1",
     "rollup-plugin-sourcemaps": "^0.4.2",

--- a/tasks/archive.js
+++ b/tasks/archive.js
@@ -28,7 +28,11 @@ gulp.task('archive:files', [
 
 gulp.task('archive:packages', [ 'build', 'minify' ], function() {
   return gulp.src([
-    'dist/**/*.{js,css}'
+    'dist/**/*.{js,css,map,d.ts}',
+    'dist/*/src/**', // source code for sourcemaps
+    'dist/*/LICENSE.*',
+    'dist/*/README.*',
+    'dist/*/package.json'
   ]).pipe(
     gulp.dest('tmp/' + archiveId + '/packages')
   )

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -24,11 +24,11 @@ gulp.task('build:raw', shell.task(
 ))
 
 const BANNER =
-  '/*!\n' +
-  '<%= title %> v<%= version %>\n' +
-  'Docs & License: <%= homepage %>\n' +
-  '(c) <%= copyright %>\n' +
-  '*/\n'
+  '/*! ' +
+  '<%= title %> v<%= version %> ' +
+  'Docs & License: <%= homepage %> ' +
+  '(c) <%= copyright %> ' +
+  '*/ '
 
 function modifySource(content, filePath) {
   let packageName = path.basename(path.dirname(filePath))

--- a/tasks/lint.js
+++ b/tasks/lint.js
@@ -20,7 +20,8 @@ ONLY checks two things:
 gulp.task('lint:js:built', [ 'build' ], function() {
   return gulp.src([
     'dist/**/*.js',
-    '!**/*.min.js'
+    '!**/*.min.js',
+    '!dist/*/src/**' // don't lint sourcemaps' source code
   ])
     .pipe(
       eslint({

--- a/tasks/minify.js
+++ b/tasks/minify.js
@@ -11,7 +11,8 @@ gulp.task('minify', [
 gulp.task('minify:js', [ 'build' ], function() {
   return gulp.src([
     'dist/*/*.js',
-    '!**/*.min.js' // avoid double minify
+    '!**/*.min.js', // avoid double minify
+    '!dist/*/src/**' // don't minify sourcemaps' source code
   ], { base: '.' })
     .pipe(
       uglify({
@@ -27,7 +28,8 @@ gulp.task('minify:js', [ 'build' ], function() {
 gulp.task('minify:css', [ 'build' ], function() {
   return gulp.src([
     'dist/*/*.css',
-    '!**/*.min.css' // avoid double minify
+    '!**/*.min.css', // avoid double minify
+    '!dist/*/src/**' // don't minify sourcemaps' source code
   ], { base: '.' })
     .pipe(
       cssmin()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitUseStrict": true,
     "importHelpers": true,
     "baseUrl": ".",
+    "sourceMap": true,
     "paths": {
       "@fullcalendar/core": [ "src/core/main" ],
       "@fullcalendar/interaction": [ "src/interaction/main" ],


### PR DESCRIPTION
Fixes #4719.  This PR improves the debugging story for app devs who use FullCalendar, so that devs (especially users of VSCode) can easily debug into the original FullCalendar source inside node_modules. 

This PR makes a few changes to the build process but doesn't make any runtime source code changes.  Here's what's new:
* Generates sourcemaps in all builds, not just dev builds.  This doesn't change the code that's downloaded in production bundles (especially not minified bundles) but simply makes sure that sourcemaps are always available.
* Updates rollup config to copy the original TS/Sass/etc source from `/src/packagename/` folders into each package's root folder. For example, `/src/core/**` gets copied into `/dist/core/src/**`
* Also copies locales source code (which is duplicated in every package) into a `/src/locales` folder of each package
* Fixes the paths in the `sources` array in sourcemaps so that sourcemaps point to the correct relative folder where the source was copied into in the steps above
* Removes newlines from the copyright/license banner that's prepended to bundle source files. This prevents line numbering from getting messed up in the sourcemap because adding the banner no longer changes the number of lines in the bundle js file.
* Ensures that license, readme, package.json, and .d.ts files are copied into the archive folders as part of the build process. This was needed for anyone who wants to build FC locally and npm install from that local build.  Previously they were missing. I'm actually unsure how publishing to npm ever worked given these missing files, unless the actual publishing to npm was using something different from `/bin/build-release.sh` that was checked into master. 

I've validated that the PR is working with the VSCode debugger as well as Chrome Dev Tools' debugger.
