### PR TITLE
Respected FirstDay setting even with week calc ISO

### DIFF
--- a/src/core/datelib/env.ts
+++ b/src/core/datelib/env.ts
@@ -63,12 +63,12 @@ export class DateEnv {
     this.weekDow = settings.locale.week.dow
     this.weekDoy = settings.locale.week.doy
 
-    if (settings.weekNumberCalculation === 'ISO') {
-      this.weekDow = 1
-      this.weekDoy = 4
-    }
     if (typeof settings.firstDay === 'number') {
       this.weekDow = settings.firstDay
+    }
+    else if (settings.weekNumberCalculation === 'ISO') {
+      this.weekDow = 1
+      this.weekDoy = 4
     }
 
     if (typeof settings.weekNumberCalculation === 'function') {

--- a/src/core/datelib/env.ts
+++ b/src/core/datelib/env.ts
@@ -66,7 +66,8 @@ export class DateEnv {
     if (settings.weekNumberCalculation === 'ISO') {
       this.weekDow = 1
       this.weekDoy = 4
-    } else if (typeof settings.firstDay === 'number') {
+    }
+    if (typeof settings.firstDay === 'number') {
       this.weekDow = settings.firstDay
     }
 

--- a/tests/automated/legacy/firstDay.js
+++ b/tests/automated/legacy/firstDay.js
@@ -59,6 +59,24 @@ describe('First Day', function() {
     })
   })
 
+  describe('when setting firstDay to 2 and weekNumberCalculation to ISO', function() {
+    pushOptions({
+      firstDay: 2,
+      weekNumberCalculation: 'ISO'
+    })
+    it('should make Tuesday the first day of the week', function() {
+      initCalendar()
+      var daysOfWeek = $('.fc-day-header')
+      expect(daysOfWeek[1]).toHaveClass('fc-tue')
+      expect(daysOfWeek[2]).toHaveClass('fc-wed')
+      expect(daysOfWeek[3]).toHaveClass('fc-thu')
+      expect(daysOfWeek[4]).toHaveClass('fc-fri')
+      expect(daysOfWeek[5]).toHaveClass('fc-sat')
+      expect(daysOfWeek[6]).toHaveClass('fc-sun')
+      expect(daysOfWeek[0]).toHaveClass('fc-mon')
+    })
+  })
+
   describe('when setting firstDay to 2', function() {
     pushOptions({
       firstDay: 2

--- a/tests/automated/legacy/firstDay.js
+++ b/tests/automated/legacy/firstDay.js
@@ -59,6 +59,23 @@ describe('First Day', function() {
     })
   })
 
+  describe('when setting firstDay to 2', function() {
+    pushOptions({
+      firstDay: 2
+    })
+    it('should make Tuesday the first day of the week', function() {
+      initCalendar()
+      var daysOfWeek = $('.fc-day-header')
+      expect(daysOfWeek[0]).toHaveClass('fc-tue')
+      expect(daysOfWeek[1]).toHaveClass('fc-wed')
+      expect(daysOfWeek[2]).toHaveClass('fc-thu')
+      expect(daysOfWeek[3]).toHaveClass('fc-fri')
+      expect(daysOfWeek[4]).toHaveClass('fc-sat')
+      expect(daysOfWeek[5]).toHaveClass('fc-sun')
+      expect(daysOfWeek[6]).toHaveClass('fc-mon')
+    })
+  })
+
   describe('when setting firstDay to 2 and weekNumberCalculation to ISO', function() {
     pushOptions({
       firstDay: 2,
@@ -74,23 +91,6 @@ describe('First Day', function() {
       expect(daysOfWeek[5]).toHaveClass('fc-sat')
       expect(daysOfWeek[6]).toHaveClass('fc-sun')
       expect(daysOfWeek[0]).toHaveClass('fc-mon')
-    })
-  })
-
-  describe('when setting firstDay to 2', function() {
-    pushOptions({
-      firstDay: 2
-    })
-    it('should make Tuesday the first day of the week', function() {
-      initCalendar()
-      var daysOfWeek = $('.fc-day-header')
-      expect(daysOfWeek[0]).toHaveClass('fc-tue')
-      expect(daysOfWeek[1]).toHaveClass('fc-wed')
-      expect(daysOfWeek[2]).toHaveClass('fc-thu')
-      expect(daysOfWeek[3]).toHaveClass('fc-fri')
-      expect(daysOfWeek[4]).toHaveClass('fc-sat')
-      expect(daysOfWeek[5]).toHaveClass('fc-sun')
-      expect(daysOfWeek[6]).toHaveClass('fc-mon')
     })
   })
 


### PR DESCRIPTION
According to the [docs](https://fullcalendar.io/docs/firstDay) when weekNumberCalculation is set to 'ISO' it defaults to firstDay setting to Monday. But with the current code the firstDay setting is ignored when weekNumberCalculation is ISO.

### Testing instructions
- Load a calendar
- Set the firstDay setting to 3
- Set the weekNumberCalculation setting to 'ISO'

The result is that it shows Monday as first day in week.

Pen to test it is here https://codepen.io/anon/pen/PrNdwo