### PR TITLE
OptionsInput: Add missing property

### DIFF
--- a/src/core/types/input-types.ts
+++ b/src/core/types/input-types.ts
@@ -247,4 +247,5 @@ export interface OptionsInput extends OptionsInputBase {
   buttonText?: ButtonTextCompoundInput
   views?: { [viewId: string]: ViewOptionsInput }
   plugins?: (PluginDef | string)[]
+  googleCalendarApiKey?: string
 }


### PR DESCRIPTION
Add `googleCalendarApiKey` property to `OptionsInput` interface