### PR TITLE
Note about compiling FC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ If you want to clean up the generated files, run:
 
 	npm run clean
 
+*Note*: If a parent directory contains any @fullcalendar/* libraries as dependencies for other projects, NPM will fail to compile FullCalendar using either `npm run build` or `npm run watch`.
 
 ## Git
 


### PR DESCRIPTION
After spending about a whole day of troubleshooting why FC wouldn't compile, I eventually figured out that if any parent directories contained dependencies for @fullcalendar/* libraries NPM would fail to compile. This warning hopefully saves somebody else from hours/days of frustration & troubleshooting