### PR TITLE
Fix defaultAllDayEventDuration to comply with documentation

### DIFF
--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -15,7 +15,7 @@ export const globalDefaults = {
   titleRangeSeparator: ' \u2013 ', // en dash
 
   defaultTimedEventDuration: '01:00:00',
-  defaultAllDayEventDuration: { day: 1 },
+  defaultAllDayEventDuration: { days: 1 },
   forceEventDuration: false,
   nextDayThreshold: '00:00:00',
 


### PR DESCRIPTION
Fixes the default value of the config option `defaultAllDayEventDuration`.

According to the documentation, it's `{ days: 1 }`, not `{ day: 1 }` like it was before.

While Fullcalendar also supports `{ day: ...}`, the documentation of the [Duration object](https://fullcalendar.io/docs/duration-object) states that:

> However, when the API emits a Duration object, it is always a plain JavaScript object with just a few keys: years, months, days, milliseconds

Hence I would expect that the default values of FullCalendar follow that convention.