### PR TITLE
Add extendedProperties coming from Google Calendar API

### DIFF
--- a/packages/google-calendar/src/main.ts
+++ b/packages/google-calendar/src/main.ts
@@ -170,7 +170,8 @@ function gcalItemToRawEventDef(item, gcalTimezone) {
     end: item.end.dateTime || item.end.date, // same
     url: url,
     location: item.location,
-    description: item.description
+    description: item.description,
+    extendedProps: item.extendedProperties || null;
   }
 }
 


### PR DESCRIPTION
`extendedProperties.share` and `extendedProperties.private` will be available at `extendedProps` of `EventObject`.