### PR TITLE
list view custom columns

### DIFF
--- a/packages/list/src/ListEventRenderer.ts
+++ b/packages/list/src/ListEventRenderer.ts
@@ -7,6 +7,15 @@ import {
 } from '@fullcalendar/core'
 import ListView from './ListView'
 
+function getObjectValue(obj, path = '') {
+  return path
+    .split('.')
+    .reduce(function(acc, attr) {
+      if ((acc != null ? acc[attr] : undefined) != null) {
+        return acc[attr];
+      }
+    }, obj);
+};
 
 export default class ListEventRenderer extends FgEventRenderer {
 
@@ -72,6 +81,20 @@ export default class ListEventRenderer extends FgEventRenderer {
       classes.push('fc-has-url')
     }
 
+    let extraHtml = ''
+
+    if (Array.isArray(this.context.options.listColumns)) {
+      extraHtml = this.context.options.listColumns.map(([ columnHeader, columnBody ]) => {
+        if (typeof columnBody === 'function') {
+          return columnBody(eventDef, this)
+        } else {
+          return `<td class="fc-list-item-column fc-widget-content">
+            <a>${ getObjectValue(eventDef, columnBody) }</a>
+          </td>`
+        }
+      }).join('\n');
+    }
+
     return '<tr class="' + classes.join(' ') + '">' +
       (this.displayEventTime ?
         '<td class="fc-list-item-time ' + theme.getClass('widgetContent') + '">' +
@@ -90,6 +113,7 @@ export default class ListEventRenderer extends FgEventRenderer {
           htmlEscape(eventDef.title || '') +
         '</a>' +
       '</td>' +
+      extraHtml +
     '</tr>'
   }
 

--- a/packages/list/src/ListEventRenderer.ts
+++ b/packages/list/src/ListEventRenderer.ts
@@ -89,7 +89,7 @@ export default class ListEventRenderer extends FgEventRenderer {
           return columnBody(eventDef, this)
         } else {
           return `<td class="fc-list-item-column fc-widget-content">
-            <a>${ getObjectValue(eventDef, columnBody) }</a>
+            <a>${ getObjectValue(eventDef, columnBody) || '' }</a>
           </td>`
         }
       }).join('\n');

--- a/packages/list/src/ListView.ts
+++ b/packages/list/src/ListView.ts
@@ -273,6 +273,22 @@ export default class ListView extends View {
     let mainFormat = createFormatter(options.listDayFormat) // TODO: cache
     let altFormat = createFormatter(options.listDayAltFormat) // TODO: cache
 
+    let extraHtml = '';
+
+    if (Array.isArray(options.listColumns)) {
+      extraHtml = options.listColumns.map(([ columnHeader ]) => {
+        if (typeof columnHeader === 'function') {
+          return columnHeader(dayDate, this)
+        } else {
+          return `<td class="fc-widget-header">
+            <span class="fc-list-heading-main">
+              ${ columnHeader }
+            </span>
+          </td>`
+        }
+      }).join('\n');
+    }
+
     return createElement('tr', {
       className: 'fc-list-heading',
       'data-date': dateEnv.formatIso(dayDate, { omitTime: true })
@@ -298,7 +314,7 @@ export default class ListView extends View {
           htmlEscape(dateEnv.format(dayDate, altFormat)) // inner HTML
         ) :
         '') +
-    '</td>') as HTMLTableRowElement
+    '</td>' + extraHtml) as HTMLTableRowElement
   }
 
 }


### PR DESCRIPTION
implements #3422

```{
  listColumns: [
    [
      'Column 1', // Column Header (gets wrapped in <td>)
      'title' // Column Body (eventDef.title) (gets wrapped in <td>)
    ],
    [
      (dayDate, view) => // Column Header (same as Column 1 header)
        `<td class="fc-widget-header">
          <span class="fc-list-heading-main">
            Column 2
          </span>
        </td>`,
      (eventDef, view) => // Column Body (same as Column 1 body)
        `<td class="fc-list-item-column fc-widget-content">
          ${eventDef.title}
        </td>`
    ]
  ]
}```