### PR TITLE
#4317 replace all style= with a data-attribute for CSP support

### DIFF
--- a/packages/core/src/Calendar.ts
+++ b/packages/core/src/Calendar.ts
@@ -167,11 +167,26 @@ export default class Calendar {
       this.renderableEventStore = createEmptyEventStore()
       this.bindHandlers()
       this.executeRender()
+      this.dataToStyle()
     } else {
       this.requestRerender()
     }
   }
 
+  dataToStyle() {
+    document.querySelectorAll('*[data-calendar-style]').forEach(node => {
+      const hasStyleAttribute = !!node.attributes['style']
+      const hasNewStyleValue = !!node.attributes['data-calendar-style'].value
+
+      if (!hasStyleAttribute && hasNewStyleValue) {
+        node['style'] = node.attributes['data-calendar-style'].value
+      } else if (hasStyleAttribute && hasNewStyleValue) {
+        node['style'] = node.attributes['style'].value + node.attributes['data-calendar-style'].value
+      }
+
+      node.removeAttribute('data-calendar-style')
+    })
+  }
 
   destroy() {
     if (this.component) {
@@ -424,7 +439,6 @@ export default class Calendar {
     let eventUiSingleBase = this.buildEventUiSingleBase(viewSpec.options)
     let eventUiBySource = this.buildEventUiBySource(state.eventSources)
     let eventUiBases = this.eventUiBases = this.buildEventUiBases(renderableEventStore.defs, eventUiSingleBase, eventUiBySource)
-
     component.receiveProps({
       ...state,
       viewSpec,

--- a/packages/core/src/component/event-rendering.ts
+++ b/packages/core/src/component/event-rendering.ts
@@ -3,7 +3,6 @@ import { EventStore } from '../structs/event-store'
 import { DateRange, invertRanges, intersectRanges } from '../datelib/date-range'
 import { Duration } from '../datelib/duration'
 import { computeVisibleDayRange } from '../util/misc'
-import { dataToStyle } from '../util/html'
 import { Seg } from './DateComponent'
 import EventApi from '../api/EventApi'
 import { EventUi, EventUiHash, combineEventUis } from './event-ui'
@@ -152,9 +151,6 @@ export function filterSegsViaEls(context: ComponentContext, segs: Seg[], isMirro
   for (let seg of segs) {
     setElSeg(seg.el, seg)
   }
-
-  setTimeout(dataToStyle, 1)
-
   return segs
 }
 

--- a/packages/core/src/component/event-rendering.ts
+++ b/packages/core/src/component/event-rendering.ts
@@ -3,6 +3,7 @@ import { EventStore } from '../structs/event-store'
 import { DateRange, invertRanges, intersectRanges } from '../datelib/date-range'
 import { Duration } from '../datelib/duration'
 import { computeVisibleDayRange } from '../util/misc'
+import { dataToStyle } from '../util/html'
 import { Seg } from './DateComponent'
 import EventApi from '../api/EventApi'
 import { EventUi, EventUiHash, combineEventUis } from './event-ui'
@@ -151,6 +152,8 @@ export function filterSegsViaEls(context: ComponentContext, segs: Seg[], isMirro
   for (let seg of segs) {
     setElSeg(seg.el, seg)
   }
+
+  setTimeout(dataToStyle, 1)
 
   return segs
 }

--- a/packages/core/src/component/renderers/FillRenderer.ts
+++ b/packages/core/src/component/renderers/FillRenderer.ts
@@ -127,7 +127,7 @@ export default abstract class FillRenderer { // use for highlight, background ev
 
     return '<' + this.fillSegTag +
       (classNames.length ? ' class="' + classNames.join(' ') + '"' : '') +
-      (css ? ' style="' + cssToStr(css) + '"' : '') +
+      (css ? ' data-calendar-style="' + cssToStr(css) + '"' : '') +
       '></' + this.fillSegTag + '>'
   }
 

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -35,7 +35,8 @@ export {
 
 export {
   htmlEscape,
-  cssToStr
+  cssToStr,
+  dataToStyle
 } from './util/html'
 
 export {

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -35,8 +35,7 @@ export {
 
 export {
   htmlEscape,
-  cssToStr,
-  dataToStyle
+  cssToStr
 } from './util/html'
 
 export {

--- a/packages/core/src/util/html.ts
+++ b/packages/core/src/util/html.ts
@@ -23,16 +23,6 @@ export function cssToStr(cssProps) {
   return statements.join(';')
 }
 
-// Convert data-calendar-style attribute to css
-export function dataToStyle(root?) {
-  const rootElement = root || document
-  rootElement.querySelectorAll('*[data-calendar-style]').forEach(node => {
-    node.style = node.dataset.calendarStyle
-    node.removeAttribute('data-calendar-style')
-  })
-}
-
-
 // Given an object hash of HTML attribute names to values,
 // generates a string that can be injected between < > in HTML
 export function attrsToStr(attrs) {

--- a/packages/core/src/util/html.ts
+++ b/packages/core/src/util/html.ts
@@ -1,4 +1,3 @@
-
 export function htmlEscape(s) {
   return (s + '').replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -22,6 +21,15 @@ export function cssToStr(cssProps) {
   }
 
   return statements.join(';')
+}
+
+// Convert data-calendar-style attribute to css
+export function dataToStyle(root?) {
+  const rootElement = root || document
+  rootElement.querySelectorAll('*[data-calendar-style]').forEach(node => {
+    node.style = node.dataset.calendarStyle
+    node.removeAttribute('data-calendar-style')
+  })
 }
 
 

--- a/packages/daygrid/src/AbstractDayGridView.ts
+++ b/packages/daygrid/src/AbstractDayGridView.ts
@@ -134,7 +134,7 @@ export default abstract class AbstractDayGridView extends View {
   // Generates an HTML attribute string for setting the width of the week number column, if it is known
   weekNumberStyleAttr() {
     if (this.weekNumberWidth != null) {
-      return 'style="width:' + this.weekNumberWidth + 'px"'
+      return 'data-calendar-style="width:' + this.weekNumberWidth + 'px"'
     }
     return ''
   }

--- a/packages/daygrid/src/DayGrid.ts
+++ b/packages/daygrid/src/DayGrid.ts
@@ -169,6 +169,7 @@ export default class DayGrid extends DateComponent<DayGridProps> {
     this.renderDateSelection(context, props.dateSelectionSegs)
     this.renderBgEvents(context, props.bgEventSegs)
     this.renderFgEvents(context, props.fgEventSegs)
+    context.calendar.dataToStyle()
     this.renderEventSelection(props.eventSelection)
     this.renderEventDrag(props.eventDrag)
     this.renderEventResize(props.eventResize)

--- a/packages/daygrid/src/DayGridFillRenderer.ts
+++ b/packages/daygrid/src/DayGridFillRenderer.ts
@@ -9,7 +9,7 @@ import {
 import DayGrid, { DayGridSeg } from './DayGrid'
 
 
-const EMPTY_CELL_HTML = '<td style="pointer-events:none"></td>'
+const EMPTY_CELL_HTML = '<td data-calendar-style="pointer-events:none"></td>'
 
 
 export default class DayGridFillRenderer extends FillRenderer {

--- a/packages/daygrid/src/SimpleDayGridEventRenderer.ts
+++ b/packages/daygrid/src/SimpleDayGridEventRenderer.ts
@@ -50,7 +50,7 @@ export default abstract class SimpleDayGridEventRenderer extends FgEventRenderer
           ''
           ) +
         (skinCss ?
-          ' style="' + skinCss + '"' :
+          ' data-calendar-style="' + skinCss + '"' :
           ''
           ) +
       '>' +

--- a/packages/list/src/ListEventRenderer.ts
+++ b/packages/list/src/ListEventRenderer.ts
@@ -81,7 +81,7 @@ export default class ListEventRenderer extends FgEventRenderer {
       '<td class="fc-list-item-marker ' + theme.getClass('widgetContent') + '">' +
         '<span class="fc-event-dot"' +
         (bgColor ?
-          ' style="background-color:' + bgColor + '"' :
+          ' data-calendar-style="background-color:' + bgColor + '"' :
           '') +
         '></span>' +
       '</td>' +

--- a/packages/list/src/ListView.ts
+++ b/packages/list/src/ListView.ts
@@ -75,6 +75,7 @@ export default class ListView extends View {
       context,
       this.eventStoreToSegs(props.eventStore, props.eventUiBases, dayRanges)
     )
+    context.calendar.dataToStyle()
   }
 
 

--- a/packages/timegrid/src/AbstractTimeGridView.ts
+++ b/packages/timegrid/src/AbstractTimeGridView.ts
@@ -315,7 +315,7 @@ export default abstract class AbstractTimeGridView extends View {
   // Generates an HTML attribute string for setting the width of the axis, if it is known
   axisStyleAttr() {
     if (this.axisWidth != null) {
-      return 'style="width:' + this.axisWidth + 'px"'
+      return 'data-calendar-style="width:' + this.axisWidth + 'px"'
     }
     return ''
   }

--- a/packages/timegrid/src/TimeGrid.ts
+++ b/packages/timegrid/src/TimeGrid.ts
@@ -256,6 +256,7 @@ export default class TimeGrid extends DateComponent<TimeGridProps> {
     this.renderDateSelection(props.dateSelectionSegs)
     this.renderFgEvents(context, props.fgEventSegs)
     this.renderBgEvents(context, props.bgEventSegs)
+    context.calendar.dataToStyle()
     this.renderEventSelection(props.eventSelection)
     this.renderEventDrag(props.eventDrag)
     this.renderEventResize(props.eventResize)

--- a/packages/timegrid/src/TimeGrid.ts
+++ b/packages/timegrid/src/TimeGrid.ts
@@ -301,7 +301,7 @@ export default class TimeGrid extends DateComponent<TimeGridProps> {
     el.innerHTML =
       '<div class="fc-bg"></div>' +
       '<div class="fc-slats"></div>' +
-      '<hr class="fc-divider ' + theme.getClass('widgetHeader') + '" style="display:none" />'
+      '<hr class="fc-divider ' + theme.getClass('widgetHeader') + '" data-calendar-style="display:none" />'
 
     this.rootBgContainerEl = el.querySelector('.fc-bg')
     this.slatContainerEl = el.querySelector('.fc-slats')

--- a/packages/timegrid/src/TimeGridEventRenderer.ts
+++ b/packages/timegrid/src/TimeGridEventRenderer.ts
@@ -149,7 +149,7 @@ export default class TimeGridEventRenderer extends FgEventRenderer {
         ''
         ) +
       (skinCss ?
-        ' style="' + skinCss + '"' :
+        ' data-calendar-style="' + skinCss + '"' :
         ''
         ) +
       '>' +


### PR DESCRIPTION
Replaced all style-tags with a data-attribute that sets the style later. this is for CSP support and fixes #4317

I've tested this against the color-options on events. On a page with the `Content-Security-Policy` header set to `default-src 'self' data:;` you used to see CSP errors in the console and the color options didn't work. With this fix the CSP errors are gone and you see the selected color.