### PR TITLE
Supress errors when interacting with calendar during rerendering

### DIFF
--- a/packages/core/src/Calendar.ts
+++ b/packages/core/src/Calendar.ts
@@ -882,7 +882,7 @@ export default class Calendar {
     if (
       !this.isHandlingWindowResize &&
       this.component && // why?
-      (ev as any).target === window // not a jqui resize event
+      (ev && (ev as any).target === window) // not a jqui resize event
     ) {
       this.isHandlingWindowResize = true
       this.updateSize()

--- a/packages/core/src/component/event-rendering.ts
+++ b/packages/core/src/component/event-rendering.ts
@@ -156,11 +156,13 @@ export function filterSegsViaEls(context: ComponentContext, segs: Seg[], isMirro
 }
 
 function setElSeg(el: HTMLElement, seg: Seg) {
-  (el as any).fcSeg = seg
+  if (el) {
+    (el as any).fcSeg = seg
+  }
 }
 
 export function getElSeg(el: HTMLElement): Seg | null {
-  return (el as any).fcSeg || null
+  return el ? (el as any).fcSeg : null
 }
 
 

--- a/packages/core/src/component/event-splitting.ts
+++ b/packages/core/src/component/event-splitting.ts
@@ -120,7 +120,7 @@ export default abstract class Splitter<PropsType extends SplittableProps = Split
     let splitHashes: { [key: string]: EventUiHash } = {}
 
     for (let defId in eventUiBases) {
-      if (defId) { // not the '' key
+      if (defId && defKeys && defKeys[defId]) { // not the '' key
         for (let key of defKeys[defId]) {
 
           if (!splitHashes[key]) {

--- a/packages/interaction/src/interactions/HitDragging.ts
+++ b/packages/interaction/src/interactions/HitDragging.ts
@@ -164,7 +164,7 @@ export default class HitDragging {
       let component = droppableStore[id].component
       let offsetTracker = offsetTrackers[id]
 
-      if (offsetTracker.isWithinClipping(offsetLeft, offsetTop)) {
+      if (offsetTracker && offsetTracker.isWithinClipping(offsetLeft, offsetTop)) {
         let originLeft = offsetTracker.computeLeft()
         let originTop = offsetTracker.computeTop()
         let positionLeft = offsetLeft - originLeft


### PR DESCRIPTION
When interacting with calendar:
- dragging events, 
- selecting dates, 
- resizing events

during calendar rerendering due to:
- event source refetch happening,
- calendar initializing,
- rerender method being called programmatically

We can get different kinds of errors:
- `e.queryHitForOffset: Cannot read property 'isWithinClipping' of undefined`,
- `windowResize: undefined is not an object (evaluating 'e.target')`
- `t.e._splitIndividualUi : Cannot read property 'length' of undefined`,
- `Wt: Cannot read property 'fcSeg' of null`.

This is probably caused by trying to mutate events that are being removed from eventStore or are already removed. This PR only makes errors not appear in console. It doesn't fix inconsistencies that can be created during such interaction. 

For example:
- we're dragging an event,
- a refetch and rerender happens,
- the event that we're dragging gets deleted from the eventStore,
- new event (representing the deleted one) takes it's place in the eventStore,
- dragging placeholder still appears and indicates we're dragging,
- (thanks to the fix we're no longer getting errors in the console),
- we drop the dragged event, 
- eventDrop get's called and placeholder gets replaced with normal event,
- we end up with 2 events (representing the same one) appearing on the calendar at the same time.

I will provide a proper issue, repro and tests to my fix ASAP.
