### PR TITLE
Make sure @fullcalendar/rrule parses rrules given as strings the same as rrules given as objects

### DIFF
--- a/packages/__tests__/src/datelib/rrule.js
+++ b/packages/__tests__/src/datelib/rrule.js
@@ -255,6 +255,27 @@ describe('rrule plugin', function() {
     expect(events[0].allDay).toBe(false)
   })
 
+  // https://github.com/fullcalendar/fullcalendar/issues/4955
+  it('can generate local dates when given an rrule string including EXDATE', function() {
+    const localDateToUTCIsoString = parseLocalDate('2018-09-04T05:00:00').toISOString()
+    const modified = localDateToUTCIsoString.replace('.000', '').replace(/[\-\:]/g, '')
+
+    const localExdate = parseLocalDate('2018-09-05T05:00:00').toISOString().replace('.000', '').replace(/[\-\:]/g, '')
+
+    initCalendar({
+      timeZone: 'local',
+      events: [
+        {
+          rrule: `DTSTART:${modified}\nRRULE:FREQ=WEEKLY\nEXDATE:${localExdate}`,
+        }
+      ]
+    })
+    let events = getSortedEvents()
+    expect(events.length).toBe(5)
+    expect(events[0].start).toEqualLocalDate('2018-09-04T05:00:00')
+    expect(events[0].end).toBe(null)
+    expect(events[0].allDay).toBe(false)
+  })
 
   function getSortedEvents() {
     let events = currentCalendar.getEvents()

--- a/packages/__tests__/src/datelib/rrule.js
+++ b/packages/__tests__/src/datelib/rrule.js
@@ -64,7 +64,7 @@ describe('rrule plugin', function() {
     expect(events[4].start).toEqualDate('2018-10-02T13:00:00Z')
   })
 
-  it('can expand monthly recurrence', function() {
+  it('can expand monthly recurrence when given an rrule object', function() {
     initCalendar({
       defaultView: 'dayGridMonth',
       now: '2018-12-25T12:00:00',
@@ -75,6 +75,21 @@ describe('rrule plugin', function() {
           count: 13,
           bymonthday: [ 13 ]
         }
+      } ]
+    })
+
+    let events = currentCalendar.getEvents()
+    expect(events.length).toBe(1)
+    expect(events[0].start).toEqualDate('2018-12-13')
+  })
+
+  // https://github.com/fullcalendar/fullcalendar/issues/4955
+  it('can expand monthly recurrence when given an rrule string', function() {
+    initCalendar({
+      defaultView: 'dayGridMonth',
+      now: '2018-12-25T12:00:00',
+      events: [ {
+        rrule: 'DTSTART:20181101\nRRULE:FREQ=MONTHLY;COUNT=13;BYMONTHDAY=13'
       } ]
     })
 
@@ -202,7 +217,7 @@ describe('rrule plugin', function() {
     expect(events[0].allDay).toBe(false)
   })
 
-  it('can generate local dates when rrule is defined in object form', function() {
+  it('can generate local dates when given an rrule object', function() {
     initCalendar({
       timeZone: 'local',
       events: [
@@ -220,8 +235,9 @@ describe('rrule plugin', function() {
     expect(events[0].end).toBe(null)
     expect(events[0].allDay).toBe(false)
   })
-  
-  it('can generate local dates when rrule is defined as icalendar string', function() {
+
+  // https://github.com/fullcalendar/fullcalendar/issues/4955
+  it('can generate local dates when given an rrule string', function() {
     const localDateToUTCIsoString = parseLocalDate('2018-09-04T05:00:00').toISOString()
     const modified = localDateToUTCIsoString.replace('.000', '').replace(/[\-\:]/g, '')
     initCalendar({

--- a/packages/__tests__/src/datelib/rrule.js
+++ b/packages/__tests__/src/datelib/rrule.js
@@ -202,7 +202,7 @@ describe('rrule plugin', function() {
     expect(events[0].allDay).toBe(false)
   })
 
-  it('can generate local dates', function() {
+  it('can generate local dates when rrule is defined in object form', function() {
     initCalendar({
       timeZone: 'local',
       events: [
@@ -211,6 +211,24 @@ describe('rrule plugin', function() {
             dtstart: parseLocalDate('2018-09-04T05:00:00').toISOString(),
             freq: 'weekly'
           }
+        }
+      ]
+    })
+    let events = getSortedEvents()
+    expect(events.length).toBe(5)
+    expect(events[0].start).toEqualLocalDate('2018-09-04T05:00:00')
+    expect(events[0].end).toBe(null)
+    expect(events[0].allDay).toBe(false)
+  })
+  
+  it('can generate local dates when rrule is defined as icalendar string', function() {
+    const localDateToUTCIsoString = parseLocalDate('2018-09-04T05:00:00').toISOString()
+    const modified = localDateToUTCIsoString.replace('.000', '').replace(/[\-\:]/g, '')
+    initCalendar({
+      timeZone: 'local',
+      events: [
+        {
+          rrule: `DTSTART:${modified}\nRRULE:FREQ=WEEKLY`,
         }
       ]
     })

--- a/packages/rrule/src/main.ts
+++ b/packages/rrule/src/main.ts
@@ -39,11 +39,14 @@ let recurring: RecurringType = {
     return null
   },
 
-  expand(rrule: RRule, framingRange: DateRange): DateMarker[] {
+  expand(rrule: RRule, framingRange: DateRange, dateEnv: DateEnv): DateMarker[] {
     // we WANT an inclusive start and in exclusive end, but the js rrule lib will only do either BOTH
     // inclusive or BOTH exclusive, which is stupid: https://github.com/jakubroztocil/rrule/issues/84
     // Workaround: make inclusive, which will generate extra occurences, and then trim.
     return rrule.between(framingRange.start, framingRange.end, true)
+      .map(function(date) {
+        return dateEnv.createMarker(date)
+      })
       .filter(function(date) {
         return date.valueOf() < framingRange.end.valueOf()
       })

--- a/packages/rrule/src/main.ts
+++ b/packages/rrule/src/main.ts
@@ -58,7 +58,7 @@ export default createPlugin({
 function parseRRule(input, dateEnv: DateEnv) {
   let allDayGuess = null
   let rrule
-  
+
   if (typeof input === 'string') {
     let rruleTemp = rrulestr(input)
 
@@ -76,8 +76,7 @@ function parseRRule(input, dateEnv: DateEnv) {
 
     if (rruleTemp.origOptions.wkst != null) {
       rruleTemp.origOptions.wkst = convertConstant(rruleTemp.origOptions.wkst)
-    }
-    else {
+    } else {
       rruleTemp.origOptions.wkst = (dateEnv.weekDow - 1 + 7) % 7 // convert Sunday-first to Monday-first
     }
 
@@ -86,8 +85,7 @@ function parseRRule(input, dateEnv: DateEnv) {
     }
 
     rrule = new RRule(rruleTemp.origOptions)
-  }
-  else if (typeof input === 'object' && input) { // non-null object
+  } else if (typeof input === 'object' && input) { // non-null object
     let refined = { ...input } // copy
 
     if (typeof refined.dtstart === 'string') {
@@ -96,8 +94,7 @@ function parseRRule(input, dateEnv: DateEnv) {
       if (dtstartMeta) {
         refined.dtstart = dtstartMeta.marker
         allDayGuess = dtstartMeta.isTimeUnspecified
-      }
-      else {
+      } else {
         delete refined.dtstart
       }
     }
@@ -112,8 +109,7 @@ function parseRRule(input, dateEnv: DateEnv) {
 
     if (refined.wkst != null) {
       refined.wkst = convertConstant(refined.wkst)
-    }
-    else {
+    } else {
       refined.wkst = (dateEnv.weekDow - 1 + 7) % 7 // convert Sunday-first to Monday-first
     }
 

--- a/packages/rrule/src/main.ts
+++ b/packages/rrule/src/main.ts
@@ -39,14 +39,18 @@ let recurring: RecurringType = {
     return null
   },
 
-  expand(rrule: RRule, framingRange: DateRange): DateMarker[] {
+  expand(rrule: RRule, framingRange: DateRange, dateEnv: DateEnv): DateMarker[] {
     // we WANT an inclusive start and in exclusive end, but the js rrule lib will only do either BOTH
     // inclusive or BOTH exclusive, which is stupid: https://github.com/jakubroztocil/rrule/issues/84
     // Workaround: make inclusive, which will generate extra occurences, and then trim.
-    return rrule.between(framingRange.start, framingRange.end, true)
-      .filter(function(date) {
-        return date.valueOf() < framingRange.end.valueOf()
-      })
+    if (rrule['fromString'] === true) {
+      return rrule.between(framingRange.start, framingRange.end, true)
+        .map(date => dateEnv.createMarker(date))
+        .filter(date => date.valueOf() < framingRange.end.valueOf())
+    } else {
+      return rrule.between(framingRange.start, framingRange.end, true)
+        .filter(date => date.valueOf() < framingRange.end.valueOf())
+    }
   }
 
 }

--- a/packages/rrule/src/main.ts
+++ b/packages/rrule/src/main.ts
@@ -70,20 +70,6 @@ function parseRRule(input, dateEnv: DateEnv) {
       rruleTemp.origOptions.until = dateEnv.createMarker(rruleTemp.origOptions.until)
     }
 
-    if (rruleTemp.origOptions.freq != null) {
-      rruleTemp.origOptions.freq = convertConstant(rruleTemp.origOptions.freq)
-    }
-
-    if (rruleTemp.origOptions.wkst != null) {
-      rruleTemp.origOptions.wkst = convertConstant(rruleTemp.origOptions.wkst)
-    } else {
-      rruleTemp.origOptions.wkst = (dateEnv.weekDow - 1 + 7) % 7 // convert Sunday-first to Monday-first
-    }
-
-    if (rruleTemp.origOptions.byweekday != null) {
-      rruleTemp.origOptions.byweekday = convertConstants(rruleTemp.origOptions.byweekday) // the plural version
-    }
-
     rrule = new RRule(rruleTemp.origOptions)
   } else if (typeof input === 'object' && input) { // non-null object
     let refined = { ...input } // copy

--- a/packages/rrule/src/main.ts
+++ b/packages/rrule/src/main.ts
@@ -58,11 +58,36 @@ export default createPlugin({
 function parseRRule(input, dateEnv: DateEnv) {
   let allDayGuess = null
   let rrule
-
+  
   if (typeof input === 'string') {
-    rrule = rrulestr(input)
+    let rruleTemp = rrulestr(input)
 
-  } else if (typeof input === 'object' && input) { // non-null object
+    if (rruleTemp.origOptions.dtstart != null) {
+      rruleTemp.origOptions.dtstart = dateEnv.createMarker(rruleTemp.origOptions.dtstart)
+    }
+
+    if (rruleTemp.origOptions.until != null) {
+      rruleTemp.origOptions.until = dateEnv.createMarker(rruleTemp.origOptions.until)
+    }
+
+    if (rruleTemp.origOptions.freq != null) {
+      rruleTemp.origOptions.freq = convertConstant(rruleTemp.origOptions.freq)
+    }
+
+    if (rruleTemp.origOptions.wkst != null) {
+      rruleTemp.origOptions.wkst = convertConstant(rruleTemp.origOptions.wkst)
+    }
+    else {
+      rruleTemp.origOptions.wkst = (dateEnv.weekDow - 1 + 7) % 7 // convert Sunday-first to Monday-first
+    }
+
+    if (rruleTemp.origOptions.byweekday != null) {
+      rruleTemp.origOptions.byweekday = convertConstants(rruleTemp.origOptions.byweekday) // the plural version
+    }
+
+    rrule = new RRule(rruleTemp.origOptions)
+  }
+  else if (typeof input === 'object' && input) { // non-null object
     let refined = { ...input } // copy
 
     if (typeof refined.dtstart === 'string') {
@@ -71,7 +96,8 @@ function parseRRule(input, dateEnv: DateEnv) {
       if (dtstartMeta) {
         refined.dtstart = dtstartMeta.marker
         allDayGuess = dtstartMeta.isTimeUnspecified
-      } else {
+      }
+      else {
         delete refined.dtstart
       }
     }
@@ -86,7 +112,8 @@ function parseRRule(input, dateEnv: DateEnv) {
 
     if (refined.wkst != null) {
       refined.wkst = convertConstant(refined.wkst)
-    } else {
+    }
+    else {
       refined.wkst = (dateEnv.weekDow - 1 + 7) % 7 // convert Sunday-first to Monday-first
     }
 

--- a/packages/rrule/src/main.ts
+++ b/packages/rrule/src/main.ts
@@ -39,14 +39,11 @@ let recurring: RecurringType = {
     return null
   },
 
-  expand(rrule: RRule, framingRange: DateRange, dateEnv: DateEnv): DateMarker[] {
+  expand(rrule: RRule, framingRange: DateRange): DateMarker[] {
     // we WANT an inclusive start and in exclusive end, but the js rrule lib will only do either BOTH
     // inclusive or BOTH exclusive, which is stupid: https://github.com/jakubroztocil/rrule/issues/84
     // Workaround: make inclusive, which will generate extra occurences, and then trim.
     return rrule.between(framingRange.start, framingRange.end, true)
-      .map(function(date) {
-        return dateEnv.createMarker(date)
-      })
       .filter(function(date) {
         return date.valueOf() < framingRange.end.valueOf()
       })

--- a/packages/rrule/src/main.ts
+++ b/packages/rrule/src/main.ts
@@ -60,17 +60,9 @@ function parseRRule(input, dateEnv: DateEnv) {
   let rrule
 
   if (typeof input === 'string') {
-    let rruleTemp = rrulestr(input)
+    rrule = rrulestr(input)
+    rrule.fromString = true
 
-    if (rruleTemp.origOptions.dtstart != null) {
-      rruleTemp.origOptions.dtstart = dateEnv.createMarker(rruleTemp.origOptions.dtstart)
-    }
-
-    if (rruleTemp.origOptions.until != null) {
-      rruleTemp.origOptions.until = dateEnv.createMarker(rruleTemp.origOptions.until)
-    }
-
-    rrule = new RRule(rruleTemp.origOptions)
   } else if (typeof input === 'object' && input) { // non-null object
     let refined = { ...input } // copy
 
@@ -104,6 +96,7 @@ function parseRRule(input, dateEnv: DateEnv) {
     }
 
     rrule = new RRule(refined)
+    rrule.fromString = false
   }
 
   if (rrule) {


### PR DESCRIPTION
This fixes an issue with the rrule plugin parsing rrule strings without taking the current timezone into account.

This fix is suggested by @paco3346 in issue #4955 and I take no credit for it. It seems to fix a problem that I really want to see fixed, so I took the liberty of creating this pull request. The first one I've ever created. :)