### PR TITLE
Add support for jQuery 3.5

### DIFF
--- a/src/Toolbar.ts
+++ b/src/Toolbar.ts
@@ -39,7 +39,7 @@ export default class Toolbar {
       el.append(this.renderSection('left'))
         .append(this.renderSection('right'))
         .append(this.renderSection('center'))
-        .append('<div class="fc-clear"/>')
+        .append('<div class="fc-clear"></div>')
     } else {
       this.removeElement()
     }

--- a/src/agenda/AgendaView.ts
+++ b/src/agenda/AgendaView.ts
@@ -131,8 +131,8 @@ export default class AgendaView extends View {
           '<tr>' +
             '<td class="' + theme.getClass('widgetContent') + '">' +
               (this.dayGrid ?
-                '<div class="fc-day-grid"/>' +
-                '<hr class="fc-divider ' + theme.getClass('widgetHeader') + '"/>' :
+                '<div class="fc-day-grid"></div>' +
+                '<hr class="fc-divider ' + theme.getClass('widgetHeader') + '"></hr>' :
                 ''
                 ) +
             '</td>' +

--- a/src/agenda/TimeGrid.ts
+++ b/src/agenda/TimeGrid.ts
@@ -201,7 +201,7 @@ export default class TimeGrid extends InteractiveDateComponent {
     this.el.html(
       '<div class="fc-bg"></div>' +
       '<div class="fc-slats"></div>' +
-      '<hr class="fc-divider ' + theme.getClass('widgetHeader') + '" style="display:none" />'
+      '<hr class="fc-divider ' + theme.getClass('widgetHeader') + '" style="display:none"></hr>'
     )
 
     this.bottomRuleEl = this.el.find('hr')
@@ -261,7 +261,7 @@ export default class TimeGrid extends InteractiveDateComponent {
           (isLabeled ? '' : ' class="fc-minor"') +
           '>' +
           (!isRTL ? axisHtml : '') +
-          '<td class="' + theme.getClass('widgetContent') + '"/>' +
+          '<td class="' + theme.getClass('widgetContent') + '"></td>' +
           (isRTL ? axisHtml : '') +
         '</tr>'
 

--- a/src/agenda/TimeGridEventRenderer.ts
+++ b/src/agenda/TimeGridEventRenderer.ts
@@ -122,15 +122,15 @@ export default class TimeGridEventRenderer extends EventRenderer {
             ''
             ) +
         '</div>' +
-        '<div class="fc-bg"/>' +
+        '<div class="fc-bg"></div>' +
         /* TODO: write CSS for this
         (isResizableFromStart ?
-          '<div class="fc-resizer fc-start-resizer" />' :
+          '<div class="fc-resizer fc-start-resizer"></div>' :
           ''
           ) +
         */
         (isResizableFromEnd ?
-          '<div class="fc-resizer fc-end-resizer" />' :
+          '<div class="fc-resizer fc-end-resizer"></div>' :
           ''
           ) +
       '</a>'

--- a/src/basic/DayGrid.ts
+++ b/src/basic/DayGrid.ts
@@ -230,7 +230,7 @@ export default class DayGrid extends InteractiveDateComponent {
 
     if (!isDayNumberVisible && !this.cellWeekNumbersVisible) {
       // no numbers in day cell (week number must be along the side)
-      return '<td/>' //  will create an empty space above events :(
+      return '<td></td>' //  will create an empty space above events :(
     }
 
     classes = this.getDayClasses(date)
@@ -702,7 +702,7 @@ export default class DayGrid extends InteractiveDateComponent {
         '<span class="fc-title">' +
           htmlEscape(title) +
         '</span>' +
-        '<div class="fc-clear"/>' +
+        '<div class="fc-clear"></div>' +
       '</div>' +
       '<div class="fc-body ' + theme.getClass('popoverContent') + '">' +
         '<div class="fc-event-container"></div>' +

--- a/src/basic/DayGridEventRenderer.ts
+++ b/src/basic/DayGridEventRenderer.ts
@@ -279,11 +279,11 @@ export default class DayGridEventRenderer extends EventRenderer {
             ) +
         '</div>' +
         (isResizableFromStart ?
-          '<div class="fc-resizer fc-start-resizer" />' :
+          '<div class="fc-resizer fc-start-resizer"></div>' :
           ''
           ) +
         (isResizableFromEnd ?
-          '<div class="fc-resizer fc-end-resizer" />' :
+          '<div class="fc-resizer fc-end-resizer"></div>' :
           ''
           ) +
       '</a>'

--- a/src/basic/DayGridFillRenderer.ts
+++ b/src/basic/DayGridFillRenderer.ts
@@ -41,7 +41,7 @@ export default class DayGridFillRenderer extends FillRenderer {
 
     skeletonEl = $(
       '<div class="fc-' + className + '-skeleton">' +
-        '<table><tr/></table>' +
+        '<table><tr></tr></table>' +
       '</div>'
     )
     trEl = skeletonEl.find('tr')
@@ -49,7 +49,7 @@ export default class DayGridFillRenderer extends FillRenderer {
     if (startCol > 0) {
       trEl.append(
         // will create (startCol + 1) td's
-        new Array(startCol + 1).join('<td/>')
+        new Array(startCol + 1).join('<td></td>')
       )
     }
 
@@ -60,7 +60,7 @@ export default class DayGridFillRenderer extends FillRenderer {
     if (endCol < colCnt) {
       trEl.append(
         // will create (colCnt - endCol) td's
-        new Array(colCnt - endCol + 1).join('<td/>')
+        new Array(colCnt - endCol + 1).join('<td></td>')
       )
     }
 

--- a/src/basic/DayGridHelperRenderer.ts
+++ b/src/basic/DayGridHelperRenderer.ts
@@ -15,7 +15,7 @@ export default class DayGridHelperRenderer extends HelperRenderer {
     // inject each new event skeleton into each associated row
     this.component.rowEls.each(function(row, rowNode) {
       let rowEl = $(rowNode) // the .fc-row
-      let skeletonEl = $('<div class="fc-helper-skeleton"><table/></div>') // will be absolutely positioned
+      let skeletonEl = $('<div class="fc-helper-skeleton"><table></table></div>') // will be absolutely positioned
       let skeletonTopEl
       let skeletonTop
 

--- a/src/list/ListView.ts
+++ b/src/list/ListView.ts
@@ -154,7 +154,7 @@ export default class ListView extends View {
     let dayIndex
     let daySegs
     let i
-    let tableEl = $('<table class="fc-list-table ' + this.calendar.theme.getClass('tableList') + '"><tbody/></table>')
+    let tableEl = $('<table class="fc-list-table ' + this.calendar.theme.getClass('tableList') + '"><tbody></tbody></table>')
     let tbodyEl = tableEl.find('tbody')
 
     for (dayIndex = 0; dayIndex < segsByDay.length; dayIndex++) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -265,7 +265,7 @@ function getIsLeftRtlScrollbars() { // responsible for caching the computation
 }
 
 function computeIsLeftRtlScrollbars() { // creates an offscreen test element, then removes it
-  let el = $('<div><div/></div>')
+  let el = $('<div><div></div></div>')
     .css({
       position: 'absolute',
       top: -1000,


### PR DESCRIPTION
In 3.5, jQuery changed the jQuery.htmlPrefilter to no more
XHTML-compliant. So tags must be closed for HTML.