### PR TITLE
Add missing keys to EventSourceFunc fetchInfo definition

### DIFF
--- a/packages/core/src/event-sources/func-event-source.ts
+++ b/packages/core/src/event-sources/func-event-source.ts
@@ -3,12 +3,16 @@ import { EventSourceError, EventSourceDef } from '../structs/event-source'
 import { EventInput } from '../structs/event'
 import { createPlugin } from '../plugin-system'
 
+export interface FetchInfo {
+  start: Date
+  end: Date
+  startStr: string
+  endStr: string
+  timeZone: string
+}
+
 export type EventSourceFunc = (
-  arg: {
-    start: Date
-    end: Date
-    timeZone: string
-  },
+  arg: FetchInfo,
   successCallback: (events: EventInput[]) => void,
   failureCallback: (error: EventSourceError) => void
 ) => (void | PromiseLike<EventInput[]>)

--- a/packages/core/src/event-sources/func-event-source.ts
+++ b/packages/core/src/event-sources/func-event-source.ts
@@ -12,7 +12,7 @@ export interface FetchInfo {
 }
 
 export type EventSourceFunc = (
-  arg: FetchInfo,
+  fetchInfo: FetchInfo,
   successCallback: (events: EventInput[]) => void,
   failureCallback: (error: EventSourceError) => void
 ) => (void | PromiseLike<EventInput[]>)


### PR DESCRIPTION
In addition to title, extracts fetchInfo into exported interface and renames generic "arg" to "fetchInfo" to match the docs.