### PR TITLE
allow object in JSON feed

### DIFF
--- a/packages/__tests__/src/legacy/events-json-feed.js
+++ b/packages/__tests__/src/legacy/events-json-feed.js
@@ -200,4 +200,26 @@ describe('events as a json feed', function() {
     expect(currentCalendar.getEventSources()[0].url).toBe('my-feed.php')
   })
 
+  it('accepts an object of objKey is set', function() {
+
+    XHRMock.get(/^my-feed\.php/, function(req, res) {
+      return res.status(200).header('content-type', 'application/json').body(
+        JSON.stringify({
+          'events': [
+            {
+              title: 'my event',
+              start: '2014-05-21'
+            }
+          ]
+        })
+      )
+    })
+
+    initCalendar({
+      events: { url: 'my-feed.php', objKey: 'events' }
+    })
+
+    expect(currentCalendar.getEvent()[0].title).toBe('my event')
+  })
+
 })

--- a/packages/common/src/event-sources/json-feed-event-source.ts
+++ b/packages/common/src/event-sources/json-feed-event-source.ts
@@ -29,7 +29,8 @@ let eventSourceDef: EventSourceDef = {
       extraParams: raw.extraParams,
       startParam: raw.startParam,
       endParam: raw.endParam,
-      timeZoneParam: raw.timeZoneParam
+      timeZoneParam: raw.timeZoneParam,
+      objKey: raw.objKey
     }
   },
 
@@ -40,6 +41,9 @@ let eventSourceDef: EventSourceDef = {
     requestJson(
       meta.method, meta.url, requestParams,
       function(rawEvents, xhr) {
+        if (meta.objKey) {
+          rawEvents = rawEvents[meta.objKey];
+        }
         success({ rawEvents, xhr })
       },
       function(errorMessage, xhr) {


### PR DESCRIPTION
[Top level JSON arrays](https://stackoverflow.com/questions/3503102/) have often been considered insecure. I am not sure if this is still the case or if all browsers have been patched. Still I think it is better to err on the side of caution.

So this adds an option to wrap JSON feeds in an object.