### PR TITLE
fix: wrong daygrid TableListItemEvent dot color

### DIFF
--- a/packages/daygrid/src/TableListItemEvent.tsx
+++ b/packages/daygrid/src/TableListItemEvent.tsx
@@ -54,7 +54,7 @@ function renderInnerContent(innerProps: EventContentArg) {
     <Fragment>
       <div
         className='fc-daygrid-event-dot'
-        style={{ backgroundColor: innerProps.backgroundColor || innerProps.borderColor }}
+        style={{ borderColor: innerProps.backgroundColor || innerProps.borderColor }}
       />
       {innerProps.timeText &&
         <div className='fc-event-time'>{innerProps.timeText}</div>


### PR DESCRIPTION
Due to the way it's implemented, the colored dot in the daygrid view depends on `borderColor` for its color. However, in the code, `backgroundColor` was set, resulting in the dot not being able to change color.

This PR changes `backgroundColor` to `borderColor`, enabling changing the color of the dot as was originally intended. There are not side effects.