### PR TITLE
Fix state parameter of loading events

### DIFF
--- a/packages/common/src/reducers/CalendarDataManager.ts
+++ b/packages/common/src/reducers/CalendarDataManager.ts
@@ -288,9 +288,9 @@ export class CalendarDataManager {
     }
 
     // TODO: use propSetHandlers in plugin system
-    if (!prevLoadingLevel && loadingLevel) {
+    if (!prevLoadingLevel && newState.loadingLevel) {
       emitter.trigger('loading', true)
-    } else if (prevLoadingLevel && !loadingLevel) {
+    } else if (prevLoadingLevel && !newState.loadingLevel) {
       emitter.trigger('loading', false)
     }
 


### PR DESCRIPTION
Use the loadingLevel of the final state, to trigger the loading
callback with the correct isLoading parameter value.

A calendar with resources would emit a sequence of

  loading(): isLoading: true
  loading(): isLoading: false
  loading(): isLoading: false
  loading(): isLoading: false

before applying this patch. With this change applied, the
sequence turns into the expected:

  loading(): isLoading: true
  loading(): isLoading: false
  loading(): isLoading: true
  loading(): isLoading: false


Codepen for FC 5.3 before applying this patch:

   https://codepen.io/px-stkn/pen/KKzMaMj

after applying this patch:

   https://codepen.io/px-stkn/pen/xxVOgpd

The reduced testcase behaves slightly different than our (more complex) scenario, but it still
emits a "true, false, false" sequence of events.
