### PR TITLE
Fix event position calculation when calendar is inside a translated/scrolling container

### DIFF
--- a/packages/common/src/interactions/pointer.ts
+++ b/packages/common/src/interactions/pointer.ts
@@ -6,5 +6,7 @@ export interface PointerDragEvent {
   pageX: number
   pageY: number
   deltaX: number
-  deltaY: number
+  deltaY: number,
+  relativeX: number,
+  relativeY: number
 }

--- a/packages/interaction/src/dnd/ElementMirror.ts
+++ b/packages/interaction/src/dnd/ElementMirror.ts
@@ -1,4 +1,4 @@
-import { removeElement, applyStyle, whenTransitionDone, Rect } from '@fullcalendar/common'
+import { removeElement, applyStyle, whenTransitionDone, Point } from '@fullcalendar/common'
 
 // Returns the left/top offset of an element relative to the document body
 function getClientPosition(el) {
@@ -31,7 +31,7 @@ export class ElementMirror {
   deltaY?: number
   sourceEl: HTMLElement | null = null
   mirrorEl: HTMLElement | null = null
-  sourceElRect: Rect | null = null // screen coords relative to viewport
+  sourceElPosition: Point | null = null // screen coords relative to viewport
 
   // options that can be set directly by caller
   parentNode: HTMLElement = document.body
@@ -40,7 +40,7 @@ export class ElementMirror {
 
   start(sourceEl: HTMLElement, pageX: number, pageY: number) {
     this.sourceEl = sourceEl
-    this.sourceElRect = getClientPosition(sourceEl)
+    this.sourceElPosition = getClientPosition(sourceEl)
     this.origScreenX = pageX - window.pageXOffset
     this.origScreenY = pageY - window.pageYOffset
     this.deltaX = 0
@@ -98,15 +98,15 @@ export class ElementMirror {
 
   doRevertAnimation(callback: () => void, revertDuration: number) {
     let mirrorEl = this.mirrorEl!
-    let finalSourceElRect = getClientPosition(this.sourceEl) // because autoscrolling might have happened
+    let finalSourceElPosition = getClientPosition(this.sourceEl) // because autoscrolling might have happened
 
     mirrorEl.style.transition =
       'top ' + revertDuration + 'ms,' +
       'left ' + revertDuration + 'ms'
 
     applyStyle(mirrorEl, {
-      left: finalSourceElRect.left,
-      top: finalSourceElRect.top
+      left: finalSourceElPosition.left,
+      top: finalSourceElPosition.top
     })
 
     whenTransitionDone(mirrorEl, () => {
@@ -127,8 +127,8 @@ export class ElementMirror {
   updateElPosition() {
     if (this.sourceEl && this.isVisible) {
       applyStyle(this.getMirrorEl(), {
-        left: this.sourceElRect!.left + this.deltaX!,
-        top: this.sourceElRect!.top + this.deltaY!
+        left: this.sourceElPosition!.left + this.deltaX!,
+        top: this.sourceElPosition!.top + this.deltaY!
       })
     }
   }

--- a/packages/interaction/src/dnd/ElementMirror.ts
+++ b/packages/interaction/src/dnd/ElementMirror.ts
@@ -1,20 +1,13 @@
 import { removeElement, applyStyle, whenTransitionDone, Point } from '@fullcalendar/common'
 
-// Returns the left/top offset of an element relative to the document body
-function getClientPosition(el) {
-  function getOffset(el, left = 0, top = 0) {
-    if (!el || el.offsetParent === document.body) {
-      return { left, top }
-    }
+function getClientPosition(el, containerEl) {
+  const containerRect = containerEl.getBoundingClientRect();
+  const rect = el.getBoundingClientRect();
 
-    return getOffset(
-      el.offsetParent,
-      left + el.offsetLeft - el.scrollLeft,
-      top + el.offsetTop - el.scrollTop
-    )
+  return {
+      left: rect.left - containerRect.left,
+      top: rect.top - containerRect.top
   }
-
-  return getOffset(el)
 }
 
 /*
@@ -40,17 +33,17 @@ export class ElementMirror {
 
   start(sourceEl: HTMLElement, pageX: number, pageY: number) {
     this.sourceEl = sourceEl
-    this.sourceElPosition = getClientPosition(sourceEl)
-    this.origScreenX = pageX - window.pageXOffset
-    this.origScreenY = pageY - window.pageYOffset
+    this.sourceElPosition = getClientPosition(sourceEl, this.parentNode)
+    this.origScreenX = pageX
+    this.origScreenY = pageY
     this.deltaX = 0
     this.deltaY = 0
     this.updateElPosition()
   }
 
   handleMove(pageX: number, pageY: number) {
-    this.deltaX = (pageX - window.pageXOffset) - this.origScreenX!
-    this.deltaY = (pageY - window.pageYOffset) - this.origScreenY!
+    this.deltaX = pageX - this.origScreenX!
+    this.deltaY = pageY - this.origScreenY!
     this.updateElPosition()
   }
 
@@ -98,7 +91,7 @@ export class ElementMirror {
 
   doRevertAnimation(callback: () => void, revertDuration: number) {
     let mirrorEl = this.mirrorEl!
-    let finalSourceElPosition = getClientPosition(this.sourceEl) // because autoscrolling might have happened
+    let finalSourceElPosition = getClientPosition(this.sourceEl, this.parentNode) // because autoscrolling might have happened
 
     mirrorEl.style.transition =
       'top ' + revertDuration + 'ms,' +
@@ -147,7 +140,7 @@ export class ElementMirror {
       mirrorEl.classList.add('fc-event-dragging')
 
       applyStyle(mirrorEl, {
-        position: 'fixed',
+        position: 'absolute',
         zIndex: this.zIndex,
         visibility: '', // in case original element was hidden by the drag effect
         boxSizing: 'border-box', // for easy width/height

--- a/packages/interaction/src/dnd/ElementMirror.ts
+++ b/packages/interaction/src/dnd/ElementMirror.ts
@@ -18,8 +18,8 @@ Must call start + handleMove + stop.
 export class ElementMirror {
 
   isVisible: boolean = false // must be explicitly enabled
-  origScreenX?: number
-  origScreenY?: number
+  offsetX?: number
+  offsetY?: number
   deltaX?: number
   deltaY?: number
   sourceEl: HTMLElement | null = null
@@ -31,19 +31,19 @@ export class ElementMirror {
   zIndex: number = 9999
   revertDuration: number = 0
 
-  start(sourceEl: HTMLElement, pageX: number, pageY: number) {
+  start(sourceEl: HTMLElement, relativeX: number, relativeY: number) {
     this.sourceEl = sourceEl
     this.sourceElPosition = getClientPosition(sourceEl, this.parentNode)
-    this.origScreenX = pageX
-    this.origScreenY = pageY
+    this.offsetX = relativeX
+    this.offsetY = relativeY
     this.deltaX = 0
     this.deltaY = 0
     this.updateElPosition()
   }
 
-  handleMove(pageX: number, pageY: number) {
-    this.deltaX = pageX - this.origScreenX!
-    this.deltaY = pageY - this.origScreenY!
+  handleMove(relativeX: number, relativeY: number) {
+    this.deltaX = relativeX - this.offsetX!
+    this.deltaY = relativeY - this.offsetY!
     this.updateElPosition()
   }
 

--- a/packages/interaction/src/dnd/ElementMirror.ts
+++ b/packages/interaction/src/dnd/ElementMirror.ts
@@ -117,10 +117,10 @@ export class ElementMirror {
   }
 
   getMirrorEl(): HTMLElement {
-    let sourceElRect = this.sourceElRect!
     let mirrorEl = this.mirrorEl
 
     if (!mirrorEl) {
+      let sourceElRect = this.sourceEl!.getBoundingClientRect()
       mirrorEl = this.mirrorEl = this.sourceEl!.cloneNode(true) as HTMLElement // cloneChildren=true
 
       // we don't want long taps or any mouse interaction causing selection/menus.

--- a/packages/interaction/src/dnd/ElementMirror.ts
+++ b/packages/interaction/src/dnd/ElementMirror.ts
@@ -1,5 +1,22 @@
 import { removeElement, applyStyle, whenTransitionDone, Rect } from '@fullcalendar/common'
 
+// Returns the left/top offset of an element relative to the document body
+function getClientPosition(el) {
+  function getOffset(el, left = 0, top = 0) {
+    if (!el || el.offsetParent === document.body) {
+      return { left, top }
+    }
+
+    return getOffset(
+      el.offsetParent,
+      left + el.offsetLeft - el.scrollLeft,
+      top + el.offsetTop - el.scrollTop
+    )
+  }
+
+  return getOffset(el)
+}
+
 /*
 An effect in which an element follows the movement of a pointer across the screen.
 The moving element is a clone of some other element.
@@ -23,7 +40,7 @@ export class ElementMirror {
 
   start(sourceEl: HTMLElement, pageX: number, pageY: number) {
     this.sourceEl = sourceEl
-    this.sourceElRect = this.sourceEl.getBoundingClientRect()
+    this.sourceElRect = getClientPosition(sourceEl)
     this.origScreenX = pageX - window.pageXOffset
     this.origScreenY = pageY - window.pageYOffset
     this.deltaX = 0
@@ -81,7 +98,7 @@ export class ElementMirror {
 
   doRevertAnimation(callback: () => void, revertDuration: number) {
     let mirrorEl = this.mirrorEl!
-    let finalSourceElRect = this.sourceEl!.getBoundingClientRect() // because autoscrolling might have happened
+    let finalSourceElRect = getClientPosition(this.sourceEl) // because autoscrolling might have happened
 
     mirrorEl.style.transition =
       'top ' + revertDuration + 'ms,' +

--- a/packages/interaction/src/dnd/FeaturefulElementDragging.ts
+++ b/packages/interaction/src/dnd/FeaturefulElementDragging.ts
@@ -79,7 +79,7 @@ export class FeaturefulElementDragging extends ElementDragging {
         // actions related to initiating dragstart+dragmove+dragend...
 
         this.mirror.setIsVisible(false) // reset. caller must set-visible
-        this.mirror.start(ev.subjectEl as HTMLElement, ev.pageX, ev.pageY) // must happen on first pointer down
+        this.mirror.start(ev.subjectEl as HTMLElement, ev.relativeX, ev.relativeY) // must happen on first pointer down
 
         this.startDelay(ev)
 
@@ -110,7 +110,7 @@ export class FeaturefulElementDragging extends ElementDragging {
 
         // a real pointer move? (not one simulated by scrolling)
         if (ev.origEvent.type !== 'scroll') {
-          this.mirror.handleMove(ev.pageX, ev.pageY)
+          this.mirror.handleMove(ev.relativeX, ev.relativeY)
           this.autoScroller.handleMove(ev.pageX, ev.pageY)
         }
 

--- a/packages/interaction/src/dnd/PointerDragging.ts
+++ b/packages/interaction/src/dnd/PointerDragging.ts
@@ -1,4 +1,4 @@
-import { config, elementClosest, Emitter, PointerDragEvent, Rect } from '@fullcalendar/common'
+import { config, elementClosest, Emitter, PointerDragEvent, Point } from '@fullcalendar/common'
 
 config.touchMouseIgnoreWait = 500
 
@@ -38,7 +38,7 @@ export class PointerDragging {
   origPageX: number
   origPageY: number
   origCurrentTarget: HTMLElement
-  origCurrentTargetRect: Rect
+  origCurrentTargetOffset: Point
   prevPageX: number
   prevPageY: number
   prevScrollX: number // at time of last pointer pageX/pageY capture
@@ -233,7 +233,9 @@ export class PointerDragging {
         pageX,
         pageY,
         deltaX: pageX - this.origPageX,
-        deltaY: pageY - this.origPageY
+        deltaY: pageY - this.origPageY,
+        relativeX: 0, // not sure what to do here
+        relativeY: 0  // not sure what to do here
       } as PointerDragEvent)
     }
   }
@@ -257,7 +259,7 @@ export class PointerDragging {
       this.origPageX = ev.pageX
       this.origPageY = ev.pageY
       this.origCurrentTarget = ev.currentTarget as HTMLElement
-      this.origCurrentTargetRect = this.origCurrentTarget.getBoundingClientRect 
+      this.origCurrentTargetOffset = this.origCurrentTarget.getBoundingClientRect 
         ? this.origCurrentTarget.getBoundingClientRect()
         : { left: 0, top: 0 }
     } else {
@@ -273,8 +275,8 @@ export class PointerDragging {
       pageY: ev.pageY,
       deltaX,
       deltaY,
-      relativeX: ev.clientX - this.origCurrentTargetRect.left - this.origCurrentTarget.clientLeft + this.origCurrentTarget.scrollLeft - window.pageXOffset,
-      relativeY: ev.clientY - this.origCurrentTargetRect.top - this.origCurrentTarget.clientTop + this.origCurrentTarget.scrollTop - window.pageYOffset
+      relativeX: ev.clientX - this.origCurrentTargetOffset.left - this.origCurrentTarget.clientLeft + this.origCurrentTarget.scrollLeft - window.pageXOffset,
+      relativeY: ev.clientY - this.origCurrentTargetOffset.top - this.origCurrentTarget.clientTop + this.origCurrentTarget.scrollTop - window.pageYOffset
     }
   }
 
@@ -311,7 +313,9 @@ export class PointerDragging {
       pageX,
       pageY,
       deltaX,
-      deltaY
+      deltaY,
+      relativeX: 0, // not sure what to do for touch
+      relativeY: 0  // not sure what to do for touch
     }
   }
 

--- a/packages/interaction/src/dnd/PointerDragging.ts
+++ b/packages/interaction/src/dnd/PointerDragging.ts
@@ -1,4 +1,4 @@
-import { config, elementClosest, Emitter, PointerDragEvent } from '@fullcalendar/common'
+import { config, elementClosest, Emitter, PointerDragEvent, Rect } from '@fullcalendar/common'
 
 config.touchMouseIgnoreWait = 500
 
@@ -37,6 +37,8 @@ export class PointerDragging {
   wasTouchScroll: boolean = false
   origPageX: number
   origPageY: number
+  origCurrentTarget: HTMLElement
+  origCurrentTargetRect: Rect
   prevPageX: number
   prevPageY: number
   prevScrollX: number // at time of last pointer pageX/pageY capture
@@ -254,6 +256,10 @@ export class PointerDragging {
     if (isFirst) {
       this.origPageX = ev.pageX
       this.origPageY = ev.pageY
+      this.origCurrentTarget = ev.currentTarget as HTMLElement
+      this.origCurrentTargetRect = this.origCurrentTarget.getBoundingClientRect 
+        ? this.origCurrentTarget.getBoundingClientRect()
+        : { left: 0, top: 0 }
     } else {
       deltaX = ev.pageX - this.origPageX
       deltaY = ev.pageY - this.origPageY
@@ -266,7 +272,9 @@ export class PointerDragging {
       pageX: ev.pageX,
       pageY: ev.pageY,
       deltaX,
-      deltaY
+      deltaY,
+      relativeX: ev.clientX - this.origCurrentTargetRect.left - this.origCurrentTarget.clientLeft + this.origCurrentTarget.scrollLeft - window.pageXOffset,
+      relativeY: ev.clientY - this.origCurrentTargetRect.top - this.origCurrentTarget.clientTop + this.origCurrentTarget.scrollTop - window.pageYOffset
     }
   }
 


### PR DESCRIPTION
Fixes: https://github.com/fullcalendar/fullcalendar/issues/4673
Fixes: https://github.com/fullcalendar/fullcalendar/pull/4674

**Description**
Dragged calendar event can get severely misaligned when the calendar element is inside a transformed element. This makes moving events around very confusing especially when the calendar is placed within complex layouts.

**Reduced Test Case**
Reposting test case from issue 4673: https://codepen.io/coolcyberbrain/pen/oRjaLv

**Steps to Reproduce**
Render calendar inside a CSS translated container. The situation becomes worse if one of the offset parents is scrolled as well.

**Analysis**
The current implementation calculates position based on only the current offset parent of the event being dragged. This means any CSS transforms/scrolling of parent elements are unaccounted for.

A new utility function `getClientPosition` has been created that will recursively collect all the offsets/scroll position to calculate a more accurate position for cursor tracking. This utility function will handle any number of parent elements with CSS positioning/scrolling so should be much more robust in more complex layout scenarios. I wasn't sure if this function would be useful anywhere else so I opted to keep it in the same module rather than extract it into some place like `/common/util/`