### PR TITLE
Improve Dutch translation of "previous"

### DIFF
--- a/packages/core/src/locales/nl.ts
+++ b/packages/core/src/locales/nl.ts
@@ -7,7 +7,7 @@ export default {
     doy: 4  // The week that contains Jan 4th is the first week of the year.
   },
   buttonText: {
-    prev: "Voorgaand",
+    prev: "Vorige",
     next: "Volgende",
     today: "Vandaag",
     year: "Jaar",


### PR DESCRIPTION
Change "Voorgaande" into "Vorige".

Both forms are grammatical in Dutch, but "Vorige" is shorter and less archaic