### PR TITLE
docs: Fix simple typo, descrimination -> discrimination

### DIFF
--- a/packages/__tests__/src/legacy/dateClick.js
+++ b/packages/__tests__/src/legacy/dateClick.js
@@ -27,7 +27,7 @@ describe('dateClick', function() {
           let calendar = initCalendar({
             dateClick(arg) {
               expect(arg.date instanceof Date).toEqual(true)
-              expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+              expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
               expect(typeof arg.view).toEqual('object') // "
               expect(arg.allDay).toEqual(true)
               expect(arg.date).toEqualDate('2014-05-07')
@@ -49,7 +49,7 @@ describe('dateClick', function() {
           let calendar = initCalendar({
             dateClick(arg) {
               expect(arg.date instanceof Date).toEqual(true)
-              expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+              expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
               expect(typeof arg.view).toEqual('object') // "
               expect(arg.allDay).toEqual(true)
               expect(arg.date).toEqualDate('2014-05-28')
@@ -67,7 +67,7 @@ describe('dateClick', function() {
             scrollTime: '07:00:00',
             dateClick(arg) {
               expect(arg.date instanceof Date).toEqual(true)
-              expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+              expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
               expect(typeof arg.view).toEqual('object') // "
               expect(arg.allDay).toEqual(false)
               expect(arg.date).toEqualDate('2014-05-28T09:00:00Z')
@@ -87,7 +87,7 @@ describe('dateClick', function() {
             slotMinTime: '02:00:00',
             dateClick(arg) {
               expect(arg.date instanceof Date).toEqual(true)
-              expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+              expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
               expect(typeof arg.view).toEqual('object') // "
               expect(arg.allDay).toEqual(false)
               expect(arg.date).toEqualDate('2014-05-28T11:00:00Z')
@@ -106,7 +106,7 @@ describe('dateClick', function() {
             scrollTime: '23:00:00',
             dateClick(arg) {
               expect(arg.date instanceof Date).toEqual(true)
-              expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+              expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
               expect(typeof arg.view).toEqual('object') // "
               expect(arg.allDay).toEqual(false)
               expect(arg.date).toEqualDate('2014-05-28T23:30:00Z')
@@ -143,7 +143,7 @@ describe('dateClick', function() {
       let calendar = initCalendar({
         dateClick(arg) {
           expect(arg.date instanceof Date).toEqual(true)
-          expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+          expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
           expect(typeof arg.view).toEqual('object') // "
           expect(arg.allDay).toEqual(true)
           expect(arg.date).toEqualDate('2014-05-07')
@@ -179,7 +179,7 @@ describe('dateClick', function() {
       let calendar = initCalendar({
         dateClick(arg) {
           expect(arg.date instanceof Date).toEqual(true)
-          expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+          expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
           expect(typeof arg.view).toEqual('object') // "
           expect(arg.allDay).toEqual(true)
           expect(arg.date).toEqualDate('2014-05-07')

--- a/packages/__tests__/src/legacy/event-dnd.js
+++ b/packages/__tests__/src/legacy/event-dnd.js
@@ -423,7 +423,7 @@ describe('eventDrop', function() {
   })
 
   // Initialize a calendar, run a drag, and do type-checking of all arguments for all handlers.
-  // TODO: more descrimination instead of just checking for 'object'
+  // TODO: more discrimination instead of just checking for 'object'
   function initCalendarWithSpies(options) {
 
     options.eventDragStart = (arg) => {

--- a/packages/__tests__/src/legacy/select-callback.js
+++ b/packages/__tests__/src/legacy/select-callback.js
@@ -28,7 +28,7 @@ describe('select callback', function() {
           select(arg) {
             expect(arg.start instanceof Date).toEqual(true)
             expect(arg.end instanceof Date).toEqual(true)
-            expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+            expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
             expect(typeof arg.view).toEqual('object') // "
             expect(arg.allDay).toEqual(true)
             expect(arg.start).toEqualDate('2014-04-28')
@@ -53,7 +53,7 @@ describe('select callback', function() {
           select(arg) {
             expect(arg.start instanceof Date).toEqual(true)
             expect(arg.end instanceof Date).toEqual(true)
-            expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+            expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
             expect(typeof arg.view).toEqual('object') // "
             expect(arg.allDay).toEqual(true)
             expect(arg.start).toEqualDate('2014-04-28')
@@ -78,7 +78,7 @@ describe('select callback', function() {
           select(arg) {
             expect(arg.start instanceof Date).toEqual(true)
             expect(arg.end instanceof Date).toEqual(true)
-            expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+            expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
             expect(typeof arg.view).toEqual('object') // "
             expect(arg.allDay).toEqual(true)
             expect(arg.start).toEqualDate('2014-04-28')
@@ -111,7 +111,7 @@ describe('select callback', function() {
             select(arg) {
               expect(arg.start instanceof Date).toEqual(true)
               expect(arg.end instanceof Date).toEqual(true)
-              expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+              expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
               expect(typeof arg.view).toEqual('object') // "
               expect(arg.allDay).toEqual(true)
               expect(arg.start).toEqualDate('2014-05-28')
@@ -136,7 +136,7 @@ describe('select callback', function() {
             select(arg) {
               expect(arg.start instanceof Date).toEqual(true)
               expect(arg.end instanceof Date).toEqual(true)
-              expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+              expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
               expect(typeof arg.view).toEqual('object') // "
               expect(arg.allDay).toEqual(true)
               expect(arg.start).toEqualDate('2014-05-28')
@@ -164,7 +164,7 @@ describe('select callback', function() {
             select(arg) {
               expect(arg.start instanceof Date).toEqual(true)
               expect(arg.end instanceof Date).toEqual(true)
-              expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+              expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
               expect(typeof arg.view).toEqual('object') // "
               expect(arg.allDay).toEqual(false)
               expect(arg.start).toEqualDate('2014-05-28T09:00:00Z')
@@ -209,7 +209,7 @@ describe('select callback', function() {
             select(arg) {
               expect(arg.start instanceof Date).toEqual(true)
               expect(arg.end instanceof Date).toEqual(true)
-              expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+              expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
               expect(typeof arg.view).toEqual('object') // "
               expect(arg.allDay).toEqual(false)
               expect(arg.start).toEqualDate('2014-05-28T09:00:00Z')
@@ -234,7 +234,7 @@ describe('select callback', function() {
             select(arg) {
               expect(arg.start instanceof Date).toEqual(true)
               expect(arg.end instanceof Date).toEqual(true)
-              expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+              expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
               expect(typeof arg.view).toEqual('object') // "
               expect(arg.allDay).toEqual(false)
               expect(arg.start).toEqualDate('2014-05-28T09:00:00Z')
@@ -259,7 +259,7 @@ describe('select callback', function() {
             select(arg) {
               expect(arg.start instanceof Date).toEqual(true)
               expect(arg.end instanceof Date).toEqual(true)
-              expect(typeof arg.jsEvent).toEqual('object') // TODO: more descrimination
+              expect(typeof arg.jsEvent).toEqual('object') // TODO: more discrimination
               expect(typeof arg.view).toEqual('object') // "
               expect(arg.allDay).toEqual(false)
               expect(arg.start).toEqualDate('2014-05-28T09:00:00Z')


### PR DESCRIPTION
There is a small typo in packages/__tests__/src/legacy/dateClick.js, packages/__tests__/src/legacy/event-dnd.js, packages/__tests__/src/legacy/select-callback.js.

Should read `discrimination` rather than `descrimination`.

