### PR TITLE
Turning private extendedProperties visible

### DIFF
--- a/packages/google-calendar/src/main.ts
+++ b/packages/google-calendar/src/main.ts
@@ -167,7 +167,8 @@ function gcalItemToRawEventDef(item, gcalTimezone) {
     end: item.end.dateTime || item.end.date, // same
     url: url,
     location: item.location,
-    description: item.description
+    description: item.description,
+    extendedProps: item.extendedProperties
   }
 }
 


### PR DESCRIPTION
To solve problems like this https://stackoverflow.com/questions/63145351/how-to-get-all-of-the-google-calendar-extended-properties-for-an-event-with-jque