### PR TITLE
simplify code contributions via fully automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+  - init: yarn install && yarn build
+    command: yarn watch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,11 @@ Enter the directory and install FullCalendar's dependencies:
 
 *NOTE:* The install command will take a LONG time. We are working to fix this.
 
+### Online one-click setup
+
+You can use Gitpod(an online IDE which is free for Open Source) for working on issues and making Prs to this project. With a single click it will launch a workspace and automatically: clone the `fullcalendar` repo, install the dependencies, run `yarn build` and `yarn watch`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# FullCalendar [![Build Status](https://travis-ci.com/fullcalendar/fullcalendar.svg?branch=master)](https://travis-ci.com/fullcalendar/fullcalendar)
+# FullCalendar [![Build Status](https://travis-ci.com/fullcalendar/fullcalendar.svg?branch=master)](https://travis-ci.com/fullcalendar/fullcalendar) [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 A full-sized drag & drop JavaScript event calendar
 


### PR DESCRIPTION
Hi.

I work for Gitpod. This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

- clone the `fullcalendar` repo.
- install the dependencies.
- run `yarn build`.
- run `yarn watch`.

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://github.com/nisarhassan12/fullcalendar

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/103440865-f7a59380-4c6a-11eb-8fca-a55b7d2501dd.png)
