### PR TITLE
package.json: fix example:open call

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "example:run": "node ./scripts/example-run.js",
     "example:npm": "node ./scripts/example-npm.js",
     "example:pnp": "node ./scripts/example-pnp.js",
-    "example:open": "./script/example-open.sh",
+    "example:open": "./scripts/example-open.sh",
     "clean": "./scripts/clean.sh",
     "lint": "gulp lint",
     "lintBuilt": "gulp lintBuilt",


### PR DESCRIPTION
While getting the dev environment setup and playing around with some of the commands, I noticed that this particular command was pointing at the wrong location. This PR fixes that.

./script/example-open.sh -> ./scripts/example-open.sh