### PR TITLE
fix UNTIL at the end of rrule

### DIFF
--- a/packages/rrule/src/main.ts
+++ b/packages/rrule/src/main.ts
@@ -154,7 +154,7 @@ function analyzeRRuleString(str) {
 
   str.replace(/\b(DTSTART:)([^\n]*)/, processMatch)
   str.replace(/\b(EXDATE:)([^\n]*)/, processMatch)
-  str.replace(/\b(UNTIL=)([^;]*)/, processMatch)
+  str.replace(/\b(UNTIL=)([^;\n]*)/, processMatch)
 
   return { isTimeSpecified, isTimeZoneSpecified }
 }


### PR DESCRIPTION
Include \n in UNTIL regex exclusion. This fixes input strings such as:
```
DTSTART;TZID=America/New_York:20210112T080000
RRULE:FREQ=MONTHLY;UNTIL=20210110T070000
RDATE;TZID=America/New_York:20210112T080000
```
Without this fix, parsing this input string results in a null exception.