### PR TITLE
Feature: Add location, organizer and description from ICAL events

### DIFF
--- a/packages/icalendar/src/main.ts
+++ b/packages/icalendar/src/main.ts
@@ -147,6 +147,11 @@ function expandICalEvents(iCalEvents: ICAL.Event[], range: DateRange): EventInpu
             title: iCalEvent.summary,
             start: startDateTime.toString(),
             end: null, // TODO
+            extendedProps: {
+                location: iCalEvent.location,
+                organizer: iCalEvent.organizer,
+                description: iCalEvent.description,
+            },
           })
         }
       }
@@ -165,6 +170,11 @@ function buildSingleEvent(iCalEvent: ICAL.Event): EventInput {
     title: iCalEvent.summary,
     start: iCalEvent.startDate.toString(),
     end: (iCalEvent.endDate ? iCalEvent.endDate.toString() : null),
+    extendedProps: {
+        location: iCalEvent.location,
+        organizer: iCalEvent.organizer,
+        description: iCalEvent.description,
+    },
   }
 }
 


### PR DESCRIPTION
This pull request will load the event organizer, location and description from ICAL calendars when using them as an event source. They are inserted as attributes of event.extendedProps.

This should make some common ICAL usecases possible, and solves #6097 