### PR TITLE
Fix ICAL recurring event start and end times

### DIFF
--- a/packages/icalendar/src/main.ts
+++ b/packages/icalendar/src/main.ts
@@ -129,15 +129,17 @@ function parseICalFeed(feedStr: string): ICAL.Event[] {
 
 function expandICalEvents(iCalEvents: ICAL.Event[], range: DateRange): EventInput[] {
   let eventInputs: EventInput[] = []
-  let rangeStart = addDays(range.start, -1) // account for current TZ needing before UTC date
-  let rangeEnd = addDays(range.end, 1) // same. TODO: consider duration?
+  let rangeEnd = addDays(range.end, 1) // TODO: consider duration?
 
   for (let iCalEvent of iCalEvents) {
     if (iCalEvent.isRecurring()) {
-      let expansion = iCalEvent.iterator(ICAL.Time.fromJSDate(rangeStart))
+      // TODO: Handle iCalEvent.exceptions
+      let expansion = iCalEvent.iterator()
       let startDateTime: ICAL.Time
 
       while ((startDateTime = expansion.next())) {
+        let endDateTime = startDateTime.clone()
+        endDateTime.addDuration(iCalEvent.duration)
         let startDate = startDateTime.toJSDate()
 
         if (startDate.valueOf() >= rangeEnd.valueOf()) {
@@ -146,7 +148,7 @@ function expandICalEvents(iCalEvents: ICAL.Event[], range: DateRange): EventInpu
           eventInputs.push({
             title: iCalEvent.summary,
             start: startDateTime.toString(),
-            end: null, // TODO
+            end: endDateTime.toString(),
           })
         }
       }


### PR DESCRIPTION
The starting time was defined in the iCalEvent.iterator call wrongly as UTC midnight, whereas it should be the iCalEvent.startDate (the default when no arguments are given).

For an example of this going wrong, see this calendar with some test recurring events: https://ical-cors-proxy.herokuapp.com/?https://use01.thegood.cloud/remote.php/dav/public-calendars/BHNK5Arjn4S7GMGX/?export

On the current master branch, the recurring event dates are all at UTC midnight. With this branch, they will correctly be the time as set in the ICAL.