### PR TITLE
add google attachments to event extendedProps

### DIFF
--- a/packages/google-calendar/src/main.ts
+++ b/packages/google-calendar/src/main.ts
@@ -155,6 +155,7 @@ function gcalItemToRawEventDef(item, gcalTimezone) {
 
   return {
     id: item.id,
+    attachments: item.attachments || [],
     title: item.summary,
     start: item.start.dateTime || item.start.date, // try timed. will fall back to all-day
     end: item.end.dateTime || item.end.date, // same


### PR DESCRIPTION
Addresses https://github.com/fullcalendar/fullcalendar/issues/5024

Turns out attachments are [returned on the event objects](https://developers.google.com/calendar/v3/reference/events) themselves by Google.

Adding them as properties to the rawEventDef makes them propagate to extendedProperties in the FullCalendar Event so this should be the only change necessary to allow us to have access to the same attachment info