### PR TITLE
Avoid updating position when date changes

### DIFF
--- a/packages/common/src/ScrollResponder.ts
+++ b/packages/common/src/ScrollResponder.ts
@@ -27,9 +27,7 @@ export class ScrollResponder {
   }
 
   update(isDatesNew: boolean) {
-    if (isDatesNew) {
-      this.fireInitialScroll() // will drain
-    } else {
+    if (!isDatesNew) {
       this.drain()
     }
   }


### PR DESCRIPTION
Addresses #4273, https://github.com/fullcalendar/fullcalendar/issues/1037.

It seems natural to keep the scrolling position when navigating prev/next within the same view (e.g. the timeGridWeek). This PR makes a little change that seems to solve this issue. Is there a reason to update the scroll position at each view update that I don't see?