### PR TITLE
fix Popover closing inside Shadow DOM

### DIFF
--- a/packages/daygrid/src/Popover.tsx
+++ b/packages/daygrid/src/Popover.tsx
@@ -67,7 +67,8 @@ export class Popover extends BaseComponent<PopoverProps> {
     let { onClose } = this.props
 
     // only hide the popover if the click happened outside the popover
-    if (onClose && !this.rootEl.contains(ev.target)) {
+    const target = ev.composedPath?.()[0] ?? ev.target
+    if (onClose && !this.rootEl.contains(target)) {
       onClose()
     }
   }


### PR DESCRIPTION
fixes #6205

**Description**
Popover closing each time by click inside Popover. Problem actual when we using Fullcalendar inside the Shadow DOM. Click listener has an incorrect target because target equals shadow dom root element. Example: https://codesandbox.io/s/recursing-pascal-cg0md?file=/src/full-calendar-component.js.
 
Current PR fixes the problem via `composedPath()` https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath