### PR TITLE
Fix Hungarian term for "agenda"

### DIFF
--- a/packages/core/src/locales/hu.ts
+++ b/packages/core/src/locales/hu.ts
@@ -13,7 +13,7 @@ export default {
     month: 'Hónap',
     week: 'Hét',
     day: 'Nap',
-    list: 'Napló',
+    list: 'Lista',
   },
   weekText: 'Hét',
   allDayText: 'Egész nap',


### PR DESCRIPTION
The previous Hungarian translation "napló" is foreign in this context, it literally means "journal". Agenda in calendar context is better translated as "napirend" or "lista". I suggest "lista" (lit. list) which is a clear descrption of the list view. (I'm a native speaker.)

See human-curated Hungarian-English dictionary: https://szotar.sztaki.hu/search?fromlang=eng&tolang=hun&searchWord=agenda&langcode=hu&u=0&langprefix=&searchMode=WORD_PREFIX&viewMode=full&ignoreAccents=0