### PR TITLE
Fix bug with hidden/overlapped events in V3

### DIFF
--- a/src/agenda/TimeGridEventRenderer.ts
+++ b/src/agenda/TimeGridEventRenderer.ts
@@ -154,6 +154,14 @@ export default class TimeGridEventRenderer extends EventRenderer {
     let level0
     let i
 
+    // IMPORTANT TO CLEAR OLD RESULTS :(
+    for (i = 0; i < segs.length; i++) {
+      let seg = segs[i]
+      seg.level = null
+      seg.forwardCoord = null
+      seg.backwardCoord = null
+      seg.forwardPressure = null
+    }
     this.sortEventSegs(segs) // order by certain criteria
     levels = buildSlotSegLevels(segs)
     computeForwardSlotSegs(levels)
@@ -183,7 +191,7 @@ export default class TimeGridEventRenderer extends EventRenderer {
     let forwardSegs = seg.forwardSegs
     let i
 
-    if (seg.forwardCoord === undefined) { // not already computed
+    if (seg.forwardCoord == null) { // not already computed
 
       if (!forwardSegs.length) {
 


### PR DESCRIPTION
Hi There,

Not sure if you are still accepting PR for v3. We are on V3 for the foreseeable future due to a very tough upgrade for our particular use case.

We encountered the same bug as found in #2758 and #3396 and it became painful enough we took it upon ourself to find a solution. Turns out the best solution is the easiest one. This bug is not present in latest version of 5.X and thankfully this portion of the code has not changed much so it made comparing v3 to v5 incredibly easy and we were able to extract the following changes directly from 5.x to solve the issue.

The Bug as present in the latest v3.10.2: https://replit.com/@kylethielk/FullCalendarOverlapBug#index.html
The same code with the proposed fixes: https://replit.com/@kylethielk/FullCalendarOverlapBug-Fixed#index.html

Notice that in the first example the event "B" is not visible as it is hidden by "L".

