### PR TITLE
Fix sorting of resources with numbers (numberish) titles

### DIFF
--- a/packages/common/src/util/misc.ts
+++ b/packages/common/src/util/misc.ts
@@ -122,6 +122,9 @@ export function flexibleCompare(a, b) {
   if (a == null) {
     return 1
   }
+  if(!Number.isNaN(parseInt(a, 10)) && !Number.isNaN(parseInt(b, 10))) {
+    return a - b
+  }
   if (typeof a === 'string' || typeof b === 'string') {
     return String(a).localeCompare(String(b))
   }


### PR DESCRIPTION
Hi,

I have encountered a possible bug. The bug is when we pass to `<FullCalender />` react component (timeline view) resources
with titles as numbers or numberish strings like `{ title: 2 }` or `{ title: '2' }`.

My best guess is that in this case the last `if` statement in the `flexibleCompare` function gets executed. The problem is that `String.localeCompare` returns wrong values, f.e the following example returns `1`

```
const a = '6'; 
const b = '12'; 
console.log(a.localeCompare(b));
```
but this return `-1`:

```
const a = '1'; 
const b = '12';  
console.log(a.localeCompare(b));
```

However, they should return the same value for sorting to work as expected.

You can find a runnable demo [in this repo](https://github.com/turisap/fullcalendar-bug-demo).

It looks like this:

<img width="254" alt="Screenshot 2021-06-30 at 16 08 17" src="https://user-images.githubusercontent.com/28143822/123965854-8ba7ac00-d9bd-11eb-8b43-e727a36cb8a6.png">


