### PR TITLE
Add boolean type to setProp value param

### DIFF
--- a/packages/common/src/api/EventApi.ts
+++ b/packages/common/src/api/EventApi.ts
@@ -35,7 +35,7 @@ export class EventApi {
   /*
   TODO: make event struct more responsible for this
   */
-  setProp(name: string, val: string) {
+  setProp(name: string, val: string | boolean) {
     if (name in EVENT_DATE_REFINERS) {
       console.warn('Could not set date-related prop \'name\'. Use one of the date-related methods instead.')
     // TODO: make proper aliasing system?


### PR DESCRIPTION
Adds possibility to pass `boolean` values to `event.setProp` without TS errors.

resolves [#6445](https://github.com/fullcalendar/fullcalendar/issues/6445)