### PR TITLE
Fix select bug on touch device when inside a WebComponent

### DIFF
--- a/packages/interaction/src/interactions/UnselectAuto.ts
+++ b/packages/interaction/src/interactions/UnselectAuto.ts
@@ -14,7 +14,7 @@ export class UnselectAuto {
   matchesEvent = false
 
   constructor(private context: CalendarContext) {
-    let documentPointer = this.documentPointer = new PointerDragging(document)
+    let documentPointer = this.documentPointer = new PointerDragging(context.calendarApi.el.getRootNode())
     documentPointer.shouldIgnoreMove = true
     documentPointer.shouldWatchScroll = false
     documentPointer.emitter.on('pointerdown', this.onDocumentPointerDown)


### PR DESCRIPTION
This change fix the bug #6448

Because the unselect check the mousedown event is the event element here : 
```javascript
this.matchesEvent = !!elementClosest(downEl, EventDragging.SELECTOR) // interaction started on an event?
```
but in WebComponent context, if we use the main document, the target of the event is the WebComponent, not the event el which is inside.

Changing to getRootNode() on the calendar element fixes the bug because it return the "document inside WebComponent" when running inside a WebComponent or the "normal document" in classical case
