### PR TITLE
Fixed css postprocess build issue

### DIFF
--- a/packages/common/src/styles/h-event.css
+++ b/packages/common/src/styles/h-event.css
@@ -71,28 +71,28 @@ A HORIZONTAL event
 .fc-direction-ltr .fc-h-event:not(.fc-event-selected) .fc-event-resizer-start,
 .fc-direction-rtl .fc-h-event:not(.fc-event-selected) .fc-event-resizer-end {
   cursor: w-resize;
-  left: calc(var(--fc-event-resizer-thickness) / -2);
+  left: calc(-.5 * var(--fc-event-resizer-thickness));
 }
 
 .fc-direction-ltr .fc-h-event:not(.fc-event-selected) .fc-event-resizer-end,
 .fc-direction-rtl .fc-h-event:not(.fc-event-selected) .fc-event-resizer-start {
   cursor: e-resize;
-  right: calc(var(--fc-event-resizer-thickness) / -2);
+  right: calc(-.5 * var(--fc-event-resizer-thickness));
 }
 
 // resizers for TOUCH
 
 .fc-h-event.fc-event-selected .fc-event-resizer {
   top: 50%;
-  margin-top: calc(var(--fc-event-resizer-dot-total-width) / -2);
+  margin-top: calc(-.5 * var(--fc-event-resizer-dot-total-width));
 }
 
 .fc-direction-ltr .fc-h-event.fc-event-selected .fc-event-resizer-start,
 .fc-direction-rtl .fc-h-event.fc-event-selected .fc-event-resizer-end {
-  left: calc(var(--fc-event-resizer-dot-total-width) / -2);
+  left: calc(-.5 * var(--fc-event-resizer-dot-total-width));
 }
 
 .fc-direction-ltr .fc-h-event.fc-event-selected .fc-event-resizer-end,
 .fc-direction-rtl .fc-h-event.fc-event-selected .fc-event-resizer-start {
-  right: calc(var(--fc-event-resizer-dot-total-width) / -2);
+  right: calc(-.5 * var(--fc-event-resizer-dot-total-width));
 }


### PR DESCRIPTION
Context:
https://github.com/fullcalendar/fullcalendar/issues/5503#issuecomment-645654732

See https://developer.mozilla.org/en-US/docs/Web/CSS/calc
"The + and - operators must be surrounded by whitespace."

It works fine on live, but on postprocessing spaces are erased, leading to the error.

I replaced `... / -2` by `-.5 * ....`. Mathematically they are the same, but calc is happier