### PR TITLE
Offer new morePopoverClose callback option

### DIFF
--- a/packages/__tests__/src/legacy/more-link-popover.ts
+++ b/packages/__tests__/src/legacy/more-link-popover.ts
@@ -386,6 +386,30 @@ describe('more-link popover', () => {
     })
   })
 
+  it('calls the defined morePopoverClose callback when closing', (done) => {
+    const options = {
+      morePopoverClose() {},
+    }
+
+    spyOn(options, 'morePopoverClose')
+
+    let calendar = initCalendar(options)
+    let dayGridWrapper = new DayGridViewWrapper(calendar).dayGrid
+
+    dayGridWrapper.openMorePopover()
+    setTimeout(() => {
+      expect(options.morePopoverClose).not.toHaveBeenCalled()
+      expect(dayGridWrapper.getMorePopoverEl()).toBeVisible()
+
+      dayGridWrapper.closeMorePopover()
+      setTimeout(() => {
+        expect(options.morePopoverClose).toHaveBeenCalled()
+        expect(dayGridWrapper.getMorePopoverEl()).not.toBeVisible()
+        done()
+      })
+    })
+  })
+
   describe('when dragging events out', () => {
     pushOptions({
       editable: true,

--- a/packages/common/src/common/MoreLinkRoot.tsx
+++ b/packages/common/src/common/MoreLinkRoot.tsx
@@ -180,6 +180,12 @@ export class MoreLinkRoot extends BaseComponent<MoreLinkRootProps, MoreLinkRootS
   }
 
   handlePopoverClose = () => {
+    let { morePopoverClose } = this.context.options
+
+    if (typeof morePopoverClose === 'function') {
+      morePopoverClose()
+    }
+
     this.setState({ isPopoverOpen: false })
   }
 }

--- a/packages/common/src/options.ts
+++ b/packages/common/src/options.ts
@@ -238,6 +238,8 @@ export const BASE_OPTION_REFINERS = {
   moreLinkContent: identity as Identity<CustomContentGenerator<MoreLinkContentArg>>,
   moreLinkDidMount: identity as Identity<DidMountHandler<MoreLinkMountArg>>,
   moreLinkWillUnmount: identity as Identity<WillUnmountHandler<MoreLinkMountArg>>,
+
+  morePopoverClose: identity as Identity<() => void>,
 }
 
 type BuiltInBaseOptionRefiners = typeof BASE_OPTION_REFINERS


### PR DESCRIPTION
Adding an option to map a callback that gets called when the more popover window is closed.
The new option is named `morePopoverClose`.

Feature request #6593