### PR TITLE
feature  : support bootstrap 5

### DIFF
--- a/packages/__tests__/manual/bootstrap4.html
+++ b/packages/__tests__/manual/bootstrap4.html
@@ -1,128 +1,137 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-<meta charset='utf-8' />
-<link href='../../dist/fullcalendar.css' rel='stylesheet' />
-<script src='../../node_modules/moment/moment.js'></script>
-<script src='../../node_modules/jquery/dist/jquery.js'></script>
-<script src='../../dist/fullcalendar.js'></script>
+  <meta charset='utf-8' />
+  <link href='../../bundle/main.min.css' rel='stylesheet' />
+  <script src='../../bundle/main.js'></script>
+  <script src='../../bundle/locales-all.min.js'></script>
 
-<!-- using CDN for Bootstrap4 as the project currently depends on Bootstrap 3 -->
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-<script>
+  <!-- using CDN for Bootstrap4 as the project currently depends on Bootstrap 3 -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css"
+    integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
+    integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF"
+    crossorigin="anonymous"></script>
+  <script>
 
-  $(document).ready(function() {
-
-    $('#calendar').fullCalendar({
-      customButtons: {
-        myCustomButton: {
-          text: 'custom!',
-          bootstrapFontAwesome: 'fa-bell',
-          click: function() {
+    document.addEventListener('DOMContentLoaded', function () {
+      var calendarEl = document.getElementById('calendar');
+      var calendar = new FullCalendar.Calendar(calendarEl, {
+        customButtons: {
+          myCustomButton: {
+            text: 'custom!',
+            bootstrapFontAwesome: 'fa-bell',
+            click: function () {
               alert('clicked the custom button!');
+            }
           }
-        }
-      },
-      headerToolbar: {
-        left: 'prevYear,prev,today,next,nextYear',
-        center: 'title',
-        right: 'myCustomButton dayGridMonth,week,day'
-      },
-      themeSystem: 'bootstrap',
-      bootstrapFontAwesome: {
-        close: 'fa-times-circle',
-        prev: 'fa-caret-left',
-        next: 'fa-caret-right',
-        prevYear: 'fa-arrow-left',
-        nextYear: 'fa-arrow-right',
-        month: 'fa-calendar'
-      },
-      // bootstrapFontAwesome: false,
-      initialDate: '2014-08-12',
-      editable: true,
-      dayMaxEvents: true, // allow "more" link when too many events
-      events: [
-        {
-          title: 'All Day Event',
-          start: '2014-08-01'
         },
-        {
-          title: 'Long Event',
-          start: '2014-08-07',
-          end: '2014-08-10'
+        headerToolbar: {
+          left: 'prevYear,prev,today,next,nextYear',
+          center: 'title',
+          right: 'myCustomButton,dayGridMonth,dayGridWeek,timeGridWeek,listWeek,timeGridDay'
         },
-        {
-          groupId: 999,
-          title: 'Repeating Event',
-          start: '2014-08-09T16:00:00'
+        themeSystem: 'bootstrap',
+        locale: 'fr',
+        bootstrapFontAwesome: {
+          close: 'fa-times-circle',
+          prev: 'fa-caret-left',
+          next: 'fa-caret-right',
+          prevYear: 'fa-arrow-left',
+          nextYear: 'fa-arrow-right',
+          month: 'fa-calendar'
         },
-        {
-          groupId: 999,
-          title: 'Repeating Event',
-          start: '2014-08-16T16:00:00'
-        },
-        {
-          title: 'Conference',
-          start: '2014-08-11',
-          end: '2014-08-13'
-        },
-        {
-          title: 'Meeting',
-          start: '2014-08-12T10:30:00',
-          end: '2014-08-12T12:30:00'
-        },
-        {
-          title: 'Lunch',
-          start: '2014-08-12T12:00:00'
-        },
-        {
-          title: 'Meeting',
-          start: '2014-08-12T14:30:00'
-        },
-        {
-          title: 'Happy Hour',
-          start: '2014-08-12T17:30:00'
-        },
-        {
-          title: 'Dinner',
-          start: '2014-08-12T20:00:00'
-        },
-        {
-          title: 'Birthday Party',
-          start: '2014-08-13T07:00:00'
-        },
-        {
-          title: 'Click for Google',
-          url: 'http://google.com/',
-          start: '2014-08-28'
-        }
-      ]
+        navLinks: true,
+        // bootstrapFontAwesome: false,
+        initialDate: '2014-08-12',
+        editable: true,
+        dayMaxEvents: true, // allow "more" link when too many events
+        events: [
+          {
+            title: 'All Day Event',
+            start: '2014-08-01'
+          },
+          {
+            title: 'Long Event',
+            start: '2014-08-07',
+            end: '2014-08-10'
+          },
+          {
+            groupId: 999,
+            title: 'Repeating Event',
+            start: '2014-08-09T16:00:00'
+          },
+          {
+            groupId: 999,
+            title: 'Repeating Event',
+            start: '2014-08-16T16:00:00'
+          },
+          {
+            title: 'Conference',
+            start: '2014-08-11',
+            end: '2014-08-13'
+          },
+          {
+            title: 'Meeting',
+            start: '2014-08-12T10:30:00',
+            end: '2014-08-12T12:30:00'
+          },
+          {
+            title: 'Lunch',
+            start: '2014-08-12T12:00:00'
+          },
+          {
+            title: 'Meeting',
+            start: '2014-08-12T14:30:00'
+          },
+          {
+            title: 'Happy Hour',
+            start: '2014-08-12T17:30:00'
+          },
+          {
+            title: 'Dinner',
+            start: '2014-08-12T20:00:00'
+          },
+          {
+            title: 'Birthday Party',
+            start: '2014-08-13T07:00:00'
+          },
+          {
+            title: 'Click for Google',
+            url: 'http://google.com/',
+            start: '2014-08-28'
+          }
+        ]
+      }).render();
+
     });
 
-  });
+  </script>
+  <style>
+    body {
+      margin: 40px 10px;
+      padding: 0;
+      font-family: "Lucida Grande", Helvetica, Arial, Verdana, sans-serif;
+      font-size: 14px;
+    }
 
-</script>
-<style>
-
-  body {
-    margin: 40px 10px;
-    padding: 0;
-    font-family: "Lucida Grande",Helvetica,Arial,Verdana,sans-serif;
-    font-size: 14px;
-  }
-
-  #calendar {
-    max-width: 900px;
-    margin: 0 auto;
-  }
-
-</style>
+    #calendar {
+      max-width: 900px;
+      margin: 0 auto;
+    }
+  </style>
 </head>
+
 <body>
 
   <div id='calendar'></div>
 
 </body>
+
 </html>

--- a/packages/__tests__/manual/bootstrap5.html
+++ b/packages/__tests__/manual/bootstrap5.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8' />
+    <link href='../../bundle/main.min.css' rel='stylesheet' />
+    <script src='../../bundle/main.js'></script>
+    <script src='../../bundle/locales-all.min.js'></script>
+
+    <!-- using CDN for Bootstrap4 as the project currently depends on Bootstrap 3 -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
+        integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
+        crossorigin="anonymous"></script>
+    <script>
+
+        document.addEventListener('DOMContentLoaded', function () {
+            var calendarEl = document.getElementById('calendar');
+            var calendar = new FullCalendar.Calendar(calendarEl, {
+                customButtons: {
+                    myCustomButton: {
+                        text: 'custom!',
+                        bootstrapFontAwesome: 'fa-bell',
+                        click: function () {
+                            alert('clicked the custom button!');
+                        }
+                    }
+                },
+                headerToolbar: {
+                    left: 'prevYear,prev,today,next,nextYear',
+                    center: 'title',
+                    right: 'myCustomButton,dayGridMonth,dayGridWeek,timeGridWeek,listWeek,timeGridDay'
+                },
+                themeSystem: 'bootstrap5',
+                locale: 'fr',
+                bootstrapFontAwesome: {
+                    close: 'fa-times-circle',
+                    prev: 'fa-caret-left',
+                    next: 'fa-caret-right',
+                    prevYear: 'fa-arrow-left',
+                    nextYear: 'fa-arrow-right',
+                    month: 'fa-calendar'
+                },
+                navLinks: true,
+                // bootstrapFontAwesome: false,
+                initialView: 'timeGridWeek',
+                initialDate: '2014-08-12',
+                editable: true,
+                dayMaxEvents: true, // allow "more" link when too many events
+                events: [
+                    {
+                        title: 'All Day Event',
+                        start: '2014-08-01'
+                    },
+                    {
+                        title: 'Long Event',
+                        start: '2014-08-07',
+                        end: '2014-08-10'
+                    },
+                    {
+                        groupId: 999,
+                        title: 'Repeating Event',
+                        start: '2014-08-09T16:00:00'
+                    },
+                    {
+                        groupId: 999,
+                        title: 'Repeating Event',
+                        start: '2014-08-16T16:00:00'
+                    },
+                    {
+                        title: 'Conference',
+                        start: '2014-08-11',
+                        end: '2014-08-13'
+                    },
+                    {
+                        title: 'Meeting',
+                        start: '2014-08-12T10:30:00',
+                        end: '2014-08-12T12:30:00'
+                    },
+                    {
+                        title: 'Lunch',
+                        start: '2014-08-12T12:00:00'
+                    },
+                    {
+                        title: 'Meeting',
+                        start: '2014-08-12T14:30:00'
+                    },
+                    {
+                        title: 'Happy Hour',
+                        start: '2014-08-12T17:30:00'
+                    },
+                    {
+                        title: 'Dinner',
+                        start: '2014-08-12T20:00:00'
+                    },
+                    {
+                        title: 'Birthday Party',
+                        start: '2014-08-13T07:00:00'
+                    },
+                    {
+                        title: 'Click for Google',
+                        url: 'http://google.com/',
+                        start: '2014-08-28'
+                    }
+                ]
+            }).render();
+
+        });
+
+    </script>
+    <style>
+        body {
+            margin: 40px 10px;
+            padding: 0;
+            font-family: "Lucida Grande", Helvetica, Arial, Verdana, sans-serif;
+            font-size: 14px;
+        }
+
+        #calendar {
+            max-width: 900px;
+            margin: 0 auto;
+        }
+    </style>
+</head>
+
+<body>
+
+    <div id='calendar'></div>
+
+</body>
+
+</html>

--- a/packages/__tests__/manual/bootstrap5.html
+++ b/packages/__tests__/manual/bootstrap5.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset='utf-8' />
     <link href='../../bundle/main.min.css' rel='stylesheet' />
-    <script src='../../bundle/main.js'></script>
+    <script src='../../bundle/main.min.js'></script>
     <script src='../../bundle/locales-all.min.js'></script>
 
     <!-- using CDN for Bootstrap4 as the project currently depends on Bootstrap 3 -->
@@ -30,20 +30,17 @@
                     }
                 },
                 headerToolbar: {
-                    left: 'prevYear,prev,today,next,nextYear',
+                    left: 'prev,today,next',
                     center: 'title',
                     right: 'myCustomButton,dayGridMonth,dayGridWeek,timeGridWeek,listWeek,timeGridDay'
                 },
                 themeSystem: 'bootstrap5',
-                locale: 'fr',
                 bootstrapFontAwesome: {
-                    close: 'fa-times-circle',
-                    prev: 'fa-caret-left',
-                    next: 'fa-caret-right',
-                    prevYear: 'fa-arrow-left',
-                    nextYear: 'fa-arrow-right',
-                    month: 'fa-calendar'
-                },
+					prev: ' fc-icon fc-icon-chevron-left',
+					next: ' fc-icon fc-icon-chevron-right'
+				},
+                locale: 'fr',
+               
                 navLinks: true,
                 // bootstrapFontAwesome: false,
                 initialView: 'timeGridWeek',

--- a/packages/bootstrap5/.npmignore
+++ b/packages/bootstrap5/.npmignore
@@ -1,0 +1,3 @@
+/src
+/tsc
+/tsconfig.*

--- a/packages/bootstrap5/LICENSE.txt
+++ b/packages/bootstrap5/LICENSE.txt
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2021 Adam Shaw
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/bootstrap5/README.md
+++ b/packages/bootstrap5/README.md
@@ -1,0 +1,8 @@
+
+# FullCalendar Bootstrap Plugin
+
+Bootstrap 5 theming for your calendar
+
+[View the docs &raquo;](https://fullcalendar.io/docs/bootstrap-theme)
+
+This package was created from the [FullCalendar monorepo &raquo;](https://github.com/fullcalendar/fullcalendar)

--- a/packages/bootstrap5/package.json
+++ b/packages/bootstrap5/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@fullcalendar/bootstrap5",
+  "version": "5.10.1",
+  "title": "FullCalendar Bootstrap 5 Plugin",
+  "description": "Bootstrap 5 theming for your calendar",
+  "docs": "https://fullcalendar.io/docs/bootstrap-theme",
+  "dependencies": {
+    "@fullcalendar/common": "workspace:~5.10.1",
+    "tslib": "^2.1.0"
+  },
+  "main": "main.cjs.js",
+  "module": "main.js",
+  "types": "main.d.ts",
+  "jsdelivr": "main.global.min.js",
+  "browserGlobal": "FullCalendarBootstrap5",
+  "homepage": "https://fullcalendar.io/",
+  "bugs": "https://fullcalendar.io/reporting-bugs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fullcalendar/fullcalendar.git",
+    "homepage": "https://github.com/fullcalendar/fullcalendar"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Adam Shaw",
+    "email": "arshaw@arshaw.com",
+    "url": "http://arshaw.com/"
+  },
+  "devDependencies": {
+    "@fullcalendar/core-preact": "workspace:*"
+  }
+}

--- a/packages/bootstrap5/src/main.css
+++ b/packages/bootstrap5/src/main.css
@@ -1,0 +1,53 @@
+.fc-theme-bootstrap5 {
+
+    & td,
+    & th {
+        border: 1px solid var(--fc-border-color);
+    }
+    & .fc-popover {
+        border: 1px solid var(--fc-border-color);
+        background: var(--fc-page-bg-color);
+    }
+
+    & .fc-popover-header {
+        background: var(--fc-neutral-bg-color);
+    }
+
+    & .fc-popover {
+        border: 1px solid var(--fc-border-color);
+        background: var(--fc-page-bg-color);
+    }
+
+    & .fc-popover-header {
+        background: var(--fc-neutral-bg-color);
+    }
+
+    & .table-bordered {
+        border: 1px solid var(--fc-border-color);
+    }
+
+    & .table-bordered.fc-scrollgrid {
+        border-right-width: 0!important;
+    }
+
+    & .fc-list-day-cushion {
+        background-color: var(--fc-neutral-bg-color);
+    }
+
+    & .fc-list {
+        border: 1px solid var(--fc-border-color);
+    }
+
+    & .table-active {
+        background-color: rgba(0, 0, 0, 0.1); // Bootstrap value for active class table (not accessible if don't use .table class)
+    }
+
+    & .fc-timegrid-divider.table-active{
+        height: 4px;
+    }
+
+    & .border-top-dotted {
+        border-top-style: dotted;
+    }
+
+}

--- a/packages/bootstrap5/src/main.global.ts
+++ b/packages/bootstrap5/src/main.global.ts
@@ -1,0 +1,7 @@
+import { globalPlugins } from '@fullcalendar/common'
+import plugin from './main'
+
+globalPlugins.push(plugin)
+
+export default plugin
+export * from './main'

--- a/packages/bootstrap5/src/main.ts
+++ b/packages/bootstrap5/src/main.ts
@@ -2,37 +2,37 @@ import { Theme, createPlugin } from '@fullcalendar/common'
 import './main.css'
 
 export class Bootstrap5Theme extends Theme {
-  classes = {
-    root: 'fc-theme-bootstrap5', // TODO: compute this off of registered theme name
-    table: 'table-bordered', // don't attache the `table` class. we only want the borders, not any layout
-    tableCellShaded: 'table-active',
-    buttonGroup: 'btn-group',
-    button: 'btn btn-primary',
-    buttonActive: 'active',
-    popover: 'popover',
-    popoverHeader: 'popover-header',
-    popoverContent: 'popover-body',
-  }
-
-  baseIconClass = 'fa'
-  iconClasses = {
-    close: 'fa-times',
-    prev: 'fa-chevron-left',
-    next: 'fa-chevron-right',
-    prevYear: 'fa-angle-double-left',
-    nextYear: 'fa-angle-double-right',
-  }
-  rtlIconClasses = {
-    prev: 'fa-chevron-right',
-    next: 'fa-chevron-left',
-    prevYear: 'fa-angle-double-right',
-    nextYear: 'fa-angle-double-left',
-  }
-
-  iconOverrideOption = 'bootstrapFontAwesome' // TODO: make TS-friendly. move the option-processing into this plugin
-  iconOverrideCustomButtonOption = 'bootstrapFontAwesome'
-  iconOverridePrefix = 'fa-'
 }
+Bootstrap5Theme.prototype.classes = {
+  root: 'fc-theme-bootstrap5', // TODO: compute this off of registered theme name
+  table: 'table-bordered', // don't attache the `table` class. we only want the borders, not any layout
+  tableCellShaded: 'table-active',
+  buttonGroup: 'btn-group',
+  button: 'btn btn-primary',
+  buttonActive: 'active',
+  popover: 'popover',
+  popoverHeader: 'popover-header',
+  popoverContent: 'popover-body',
+}
+
+Bootstrap5Theme.prototype.baseIconClass = 'fa'
+Bootstrap5Theme.prototype.iconClasses = {
+  close: 'fa-times',
+  prev: 'fa-chevron-left',
+  next: 'fa-chevron-right',
+  prevYear: 'fa-angle-double-left',
+  nextYear: 'fa-angle-double-right',
+}
+Bootstrap5Theme.prototype.rtlIconClasses = {
+  prev: 'fa-chevron-right',
+  next: 'fa-chevron-left',
+  prevYear: 'fa-angle-double-right',
+  nextYear: 'fa-angle-double-left',
+}
+
+Bootstrap5Theme.prototype.iconOverrideOption = 'bootstrapFontAwesome' // TODO: make TS-friendly. move the option-processing into this plugin
+Bootstrap5Theme.prototype.iconOverrideCustomButtonOption = 'bootstrapFontAwesome'
+Bootstrap5Theme.prototype.iconOverridePrefix = 'fa-'
 
 const plugin = createPlugin({
   themeClasses: {

--- a/packages/bootstrap5/src/main.ts
+++ b/packages/bootstrap5/src/main.ts
@@ -1,0 +1,43 @@
+import { Theme, createPlugin } from '@fullcalendar/common'
+import './main.css'
+
+export class Bootstrap5Theme extends Theme {
+  classes = {
+    root: 'fc-theme-bootstrap5', // TODO: compute this off of registered theme name
+    table: 'table-bordered', // don't attache the `table` class. we only want the borders, not any layout
+    tableCellShaded: 'table-active',
+    buttonGroup: 'btn-group',
+    button: 'btn btn-primary',
+    buttonActive: 'active',
+    popover: 'popover',
+    popoverHeader: 'popover-header',
+    popoverContent: 'popover-body',
+  }
+
+  baseIconClass = 'fa'
+  iconClasses = {
+    close: 'fa-times',
+    prev: 'fa-chevron-left',
+    next: 'fa-chevron-right',
+    prevYear: 'fa-angle-double-left',
+    nextYear: 'fa-angle-double-right',
+  }
+  rtlIconClasses = {
+    prev: 'fa-chevron-right',
+    next: 'fa-chevron-left',
+    prevYear: 'fa-angle-double-right',
+    nextYear: 'fa-angle-double-left',
+  }
+
+  iconOverrideOption = 'bootstrapFontAwesome' // TODO: make TS-friendly. move the option-processing into this plugin
+  iconOverrideCustomButtonOption = 'bootstrapFontAwesome'
+  iconOverridePrefix = 'fa-'
+}
+
+const plugin = createPlugin({
+  themeClasses: {
+    bootstrap5: Bootstrap5Theme,
+  },
+})
+
+export default plugin

--- a/packages/bootstrap5/tsconfig.json
+++ b/packages/bootstrap5/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends":  "../../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "tsc"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "references": [
+    { "path": "../common" }
+  ]
+}

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -6,6 +6,7 @@
   "docs": "https://fullcalendar.io/docs/initialize-globals",
   "devDependencies": {
     "@fullcalendar/bootstrap": "workspace:~5.10.1",
+    "@fullcalendar/bootstrap5": "workspace:~5.10.1",
     "@fullcalendar/core": "workspace:~5.10.1",
     "@fullcalendar/daygrid": "workspace:~5.10.1",
     "@fullcalendar/google-calendar": "workspace:~5.10.1",

--- a/packages/bundle/src/main.ts
+++ b/packages/bundle/src/main.ts
@@ -4,6 +4,7 @@ import dayGridPlugin from '@fullcalendar/daygrid'
 import timeGridPlugin from '@fullcalendar/timegrid'
 import listPlugin from '@fullcalendar/list'
 import bootstrapPlugin from '@fullcalendar/bootstrap'
+import bootstrap5Plugin from '@fullcalendar/bootstrap5'
 import googleCalendarPlugin from '@fullcalendar/google-calendar'
 
 globalPlugins.push(
@@ -12,6 +13,7 @@ globalPlugins.push(
   timeGridPlugin,
   listPlugin,
   bootstrapPlugin,
+  bootstrap5Plugin,
   googleCalendarPlugin,
 )
 

--- a/packages/timegrid/src/TimeColsSlatsBody.tsx
+++ b/packages/timegrid/src/TimeColsSlatsBody.tsx
@@ -35,10 +35,18 @@ export class TimeColsSlatsBody extends BaseComponent<TimeColsSlatsBodyProps> {
             slatMeta.isLabeled ? '' : 'fc-timegrid-slot-minor',
           ]
 
+          let parentClassName = ''
+
+          // In bootstrap 5, border apply to 'tr' instead of 'td', so we apply dot style to border here.
+          if (this.context.options.themeSystem === 'bootstrap5') {
+            parentClassName = slatMeta.isLabeled ? 'border-bottom-0 border-top-dotted' : 'fc-timegrid-slot-minor border-bottom-0'
+          }
+
           return (
             <tr
               key={slatMeta.key}
               ref={slatElRefs.createRef(slatMeta.key)}
+              className={parentClassName}
             >
               {props.axis && (
                 <TimeColsAxisCell {...slatMeta} />

--- a/packages/timegrid/src/TimeColsSlatsBody.tsx
+++ b/packages/timegrid/src/TimeColsSlatsBody.tsx
@@ -39,7 +39,7 @@ export class TimeColsSlatsBody extends BaseComponent<TimeColsSlatsBodyProps> {
 
           // In bootstrap 5, border apply to 'tr' instead of 'td', so we apply dot style to border here.
           if (this.context.options.themeSystem === 'bootstrap5') {
-            parentClassName = slatMeta.isLabeled ? 'border-bottom-0 border-top-dotted' : 'fc-timegrid-slot-minor border-bottom-0'
+            parentClassName = slatMeta.isLabeled ? 'border-bottom-0 border-top-dotted' : 'fc-timegrid-slot-minor'
           }
 
           return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "packages/interaction" },
     { "path": "packages/list" },
     { "path": "packages/bootstrap" },
+    { "path": "packages/bootstrap5" },
     { "path": "packages/google-calendar" },
     { "path": "packages/luxon" },
     { "path": "packages/moment" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2674,12 +2674,12 @@ __metadata:
     "@angular/platform-browser": ~12.0.3
     "@angular/platform-browser-dynamic": ~12.0.3
     "@angular/router": ~12.0.3
-    "@fullcalendar/angular": ^5.10.0
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/angular": ^5.10.1
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     "@types/jasmine": ~2.8.8
     "@types/jasminewd2": ~2.0.3
     "@types/node": ^12.11.1
@@ -2701,12 +2701,12 @@ __metadata:
   resolution: "@fullcalendar-example-projects/bootstrap@workspace:example-projects/bootstrap"
   dependencies:
     "@fortawesome/fontawesome-free": ^5.13.1
-    "@fullcalendar/bootstrap": ^5.10.0
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/bootstrap": ^5.10.1
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     bootstrap: ^4.5.0
     css-loader: ^4.3.0
     file-loader: ^6.1.1
@@ -2722,11 +2722,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/custom-css-vars@workspace:example-projects/custom-css-vars"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     css-loader: ^4.3.0
     mini-css-extract-plugin: ^1.2.0
     postcss-calc: ^7.0.2
@@ -2744,10 +2744,10 @@ __metadata:
     "@babel/core": ^7.14.5
     "@babel/preset-env": ^7.14.5
     "@babel/preset-react": ^7.14.5
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/react": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
-    "@fullcalendar/timeline": ^5.10.0
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/react": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
+    "@fullcalendar/timeline": ^5.10.1
     "@testing-library/jest-dom": ^5.13.0
     "@testing-library/react": ^11.2.7
     babel-jest: ^27.0.2
@@ -2761,12 +2761,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/lit@workspace:example-projects/lit"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
-    "@fullcalendar/resource-timeline": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
+    "@fullcalendar/resource-timeline": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     css-loader: ^4.3.0
     lit: ^2.0.0-rc.1
     mini-css-extract-plugin: ^1.2.0
@@ -2779,11 +2779,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/locales@workspace:example-projects/locales"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     css-loader: ^4.3.0
     mini-css-extract-plugin: ^1.2.0
     webpack: ^5.3.0
@@ -2795,9 +2795,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/moment-timezone@workspace:example-projects/moment-timezone"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
     "@fullcalendar/moment-timezone": ^5.5.0
     css-loader: ^4.3.0
     mini-css-extract-plugin: ^1.2.0
@@ -2814,12 +2814,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/moment-typescript@workspace:example-projects/moment-typescript"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
-    "@fullcalendar/moment": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
+    "@fullcalendar/moment": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     css-loader: ^4.3.0
     mini-css-extract-plugin: ^1.2.0
     moment: ^2.29.1
@@ -2835,12 +2835,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/moment@workspace:example-projects/moment"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
-    "@fullcalendar/moment": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
+    "@fullcalendar/moment": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     css-loader: ^4.3.0
     mini-css-extract-plugin: ^1.2.0
     moment: ^2.29.1
@@ -2856,11 +2856,11 @@ __metadata:
   dependencies:
     "@babel/core": ^7.12.3
     "@babel/preset-react": ^7.10.4
-    "@fullcalendar/common": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/react": ^5.10.0
+    "@fullcalendar/common": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/react": ^5.10.1
     "@fullcalendar/resource-timeline": ^5.4.0
-    "@fullcalendar/timeline": ^5.10.0
+    "@fullcalendar/timeline": ^5.10.1
     babel-plugin-transform-require-ignore: ^0.1.1
     next: ^10.0.1
     next-transpile-modules: ^4.1.0
@@ -2875,11 +2875,11 @@ __metadata:
   dependencies:
     "@babel/core": ^7.12.3
     "@babel/preset-react": ^7.10.4
-    "@fullcalendar/common": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/react": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/common": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/react": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     babel-plugin-transform-require-ignore: ^0.1.1
     next: ^10.0.1
     next-transpile-modules: ^4.1.0
@@ -2892,9 +2892,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/nuxt@workspace:example-projects/nuxt"
   dependencies:
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
-    "@fullcalendar/vue": ^5.10.0
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
+    "@fullcalendar/vue": ^5.10.1
     nuxt: ^2.15.4
     pnp-webpack-plugin: ^1.6.4
   languageName: unknown
@@ -2905,11 +2905,11 @@ __metadata:
   resolution: "@fullcalendar-example-projects/parcel-2@workspace:example-projects/parcel-2"
   dependencies:
     "@babel/core": ^7.13.16
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     parcel: 2.0.0-beta.2
   languageName: unknown
   linkType: soft
@@ -2918,11 +2918,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/parcel@workspace:example-projects/parcel"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     parcel-bundler: ^1.12.4
   languageName: unknown
   linkType: soft
@@ -2931,10 +2931,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/react-mobx-typescript@workspace:example-projects/react-mobx-typescript"
   dependencies:
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/react": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/react": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     "@types/react": ^16.9.55
     "@types/react-dom": ^16.9.9
     css-loader: ^4.3.0
@@ -2963,11 +2963,11 @@ __metadata:
     "@babel/plugin-syntax-dynamic-import": ^7.0.0
     "@babel/preset-env": ^7.0.0-beta.51
     "@babel/preset-react": ^7.0.0-beta.51
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/react": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/react": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     babel-loader: ^8.1.0
     css-loader: ^4.3.0
     html-webpack-plugin: ^4.5.0
@@ -2988,10 +2988,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/react-typescript@workspace:example-projects/react-typescript"
   dependencies:
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/react": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/react": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     "@types/react": ^16.9.55
     "@types/react-dom": ^16.9.9
     css-loader: ^4.3.0
@@ -3018,11 +3018,11 @@ __metadata:
     "@babel/plugin-syntax-dynamic-import": ^7.0.0
     "@babel/preset-env": ^7.0.0-beta.51
     "@babel/preset-react": ^7.0.0-beta.51
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/react": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/react": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     babel-loader: ^8.1.0
     css-loader: ^4.3.0
     html-webpack-plugin: ^4.5.0
@@ -3039,13 +3039,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/rollup-scheduler@workspace:example-projects/rollup-scheduler"
   dependencies:
-    "@fullcalendar/adaptive": ^5.10.0
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
+    "@fullcalendar/adaptive": ^5.10.1
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
     "@fullcalendar/resource-timeline": ^5.5.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/timegrid": ^5.10.1
     "@rollup/plugin-node-resolve": ^7.1.3
     rollup: ^1.20.0||^2.0.0
     rollup-plugin-postcss: ^2.8.2
@@ -3056,11 +3056,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/rollup@workspace:example-projects/rollup"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     "@rollup/plugin-node-resolve": ^7.1.3
     rollup: ^1.20.0||^2.0.0
     rollup-plugin-postcss: ^2.8.2
@@ -3071,14 +3071,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/typescript-scheduler@workspace:example-projects/typescript-scheduler"
   dependencies:
-    "@fullcalendar/adaptive": ^5.10.0
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
+    "@fullcalendar/adaptive": ^5.10.1
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
     "@fullcalendar/resource-timeline": ^5.5.0
-    "@fullcalendar/timegrid": ^5.10.0
-    "@fullcalendar/timeline": ^5.10.0
+    "@fullcalendar/timegrid": ^5.10.1
+    "@fullcalendar/timeline": ^5.10.1
     css-loader: ^4.3.0
     mini-css-extract-plugin: ^1.2.0
     ts-loader: ^8.0.7
@@ -3092,11 +3092,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/typescript@workspace:example-projects/typescript"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     css-loader: ^4.3.0
     mini-css-extract-plugin: ^1.2.0
     ts-loader: ^8.0.7
@@ -3110,11 +3110,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/vue-typescript@workspace:example-projects/vue-typescript"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
-    "@fullcalendar/vue": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
+    "@fullcalendar/vue": ^5.10.1
     typescript: ^4.2.4
     vite: ^2.2.1
     vite-plugin-vue2: ^1.4.4
@@ -3128,11 +3128,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/vue-vuex@workspace:example-projects/vue-vuex"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
-    "@fullcalendar/vue": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
+    "@fullcalendar/vue": ^5.10.1
     core-js: ^3.6.5
     date-fns: ^2.14.0
     vite: ^2.2.1
@@ -3146,11 +3146,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/vue3-typescript@workspace:example-projects/vue3-typescript"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
-    "@fullcalendar/vue3": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
+    "@fullcalendar/vue3": ^5.10.1
     "@vitejs/plugin-vue": ^1.2.2
     "@vue/compiler-sfc": ^3.0.11
     typescript: ^4.2.4
@@ -3165,10 +3165,10 @@ __metadata:
   dependencies:
     "@babel/core": ^7.14.3
     "@babel/preset-env": ^7.14.4
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
-    "@fullcalendar/vue": ^5.10.0
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
+    "@fullcalendar/vue": ^5.10.1
     babel-loader: ^8.2.2
     css-loader: ^4.3.0
     html-webpack-plugin: ^4.5.0
@@ -3187,13 +3187,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/webpack-scheduler@workspace:example-projects/webpack-scheduler"
   dependencies:
-    "@fullcalendar/adaptive": ^5.10.0
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
+    "@fullcalendar/adaptive": ^5.10.1
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
     "@fullcalendar/resource-timeline": ^5.5.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/timegrid": ^5.10.1
     css-loader: ^4.3.0
     mini-css-extract-plugin: ^1.2.0
     webpack: ^5.3.0
@@ -3205,11 +3205,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fullcalendar-example-projects/webpack@workspace:example-projects/webpack"
   dependencies:
-    "@fullcalendar/core": ^5.10.0
-    "@fullcalendar/daygrid": ^5.10.0
-    "@fullcalendar/interaction": ^5.10.0
-    "@fullcalendar/list": ^5.10.0
-    "@fullcalendar/timegrid": ^5.10.0
+    "@fullcalendar/core": ^5.10.1
+    "@fullcalendar/daygrid": ^5.10.1
+    "@fullcalendar/interaction": ^5.10.1
+    "@fullcalendar/list": ^5.10.1
+    "@fullcalendar/timegrid": ^5.10.1
     css-loader: ^4.3.0
     mini-css-extract-plugin: ^1.2.0
     webpack: ^5.3.0
@@ -3217,22 +3217,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/adaptive@^5.10.0, @fullcalendar/adaptive@workspace:packages-premium/adaptive, @fullcalendar/adaptive@workspace:~5.10.0":
+"@fullcalendar/adaptive@^5.10.1, @fullcalendar/adaptive@workspace:packages-premium/adaptive, @fullcalendar/adaptive@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/adaptive@workspace:packages-premium/adaptive"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
-    "@fullcalendar/premium-common": "workspace:~5.10.0"
+    "@fullcalendar/premium-common": "workspace:~5.10.1"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/angular@^5.10.0, @fullcalendar/angular@workspace:packages-contrib/angular/dist/fullcalendar":
+"@fullcalendar/angular@^5.10.1, @fullcalendar/angular@workspace:packages-contrib/angular/dist/fullcalendar":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/angular@workspace:packages-contrib/angular/dist/fullcalendar"
   dependencies:
-    "@fullcalendar/core": ~5.10.0
+    "@fullcalendar/core": ~5.10.1
     fast-deep-equal: ^3.1.1
     tslib: ^2.0.0
   peerDependencies:
@@ -3241,17 +3241,27 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/bootstrap@^5.10.0, @fullcalendar/bootstrap@workspace:packages/bootstrap, @fullcalendar/bootstrap@workspace:~5.10.0":
+"@fullcalendar/bootstrap5@workspace:packages/bootstrap5, @fullcalendar/bootstrap5@workspace:~5.10.1":
   version: 0.0.0-use.local
-  resolution: "@fullcalendar/bootstrap@workspace:packages/bootstrap"
+  resolution: "@fullcalendar/bootstrap5@workspace:packages/bootstrap5"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/common@^5.10.0, @fullcalendar/common@workspace:packages/common, @fullcalendar/common@workspace:~5.10.0, @fullcalendar/common@~5.10.0":
+"@fullcalendar/bootstrap@^5.10.1, @fullcalendar/bootstrap@workspace:packages/bootstrap, @fullcalendar/bootstrap@workspace:~5.10.1":
+  version: 0.0.0-use.local
+  resolution: "@fullcalendar/bootstrap@workspace:packages/bootstrap"
+  dependencies:
+    "@fullcalendar/common": "workspace:~5.10.1"
+    "@fullcalendar/core-preact": "workspace:*"
+    tslib: ^2.1.0
+  languageName: unknown
+  linkType: soft
+
+"@fullcalendar/common@^5.10.1, @fullcalendar/common@workspace:packages/common, @fullcalendar/common@workspace:~5.10.1, @fullcalendar/common@~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/common@workspace:packages/common"
   dependencies:
@@ -3269,72 +3279,72 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/core@^5.10.0, @fullcalendar/core@workspace:packages/core, @fullcalendar/core@workspace:~5.10.0, @fullcalendar/core@~5.10.0":
+"@fullcalendar/core@^5.10.1, @fullcalendar/core@workspace:packages/core, @fullcalendar/core@workspace:~5.10.1, @fullcalendar/core@~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/core@workspace:packages/core"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
     preact: ^10.0.5
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/daygrid@^5.10.0, @fullcalendar/daygrid@workspace:packages/daygrid, @fullcalendar/daygrid@workspace:~5.10.0, @fullcalendar/daygrid@~5.10.0":
+"@fullcalendar/daygrid@^5.10.1, @fullcalendar/daygrid@workspace:packages/daygrid, @fullcalendar/daygrid@workspace:~5.10.1, @fullcalendar/daygrid@~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/daygrid@workspace:packages/daygrid"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/google-calendar@workspace:packages/google-calendar, @fullcalendar/google-calendar@workspace:~5.10.0":
+"@fullcalendar/google-calendar@workspace:packages/google-calendar, @fullcalendar/google-calendar@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/google-calendar@workspace:packages/google-calendar"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/icalendar@workspace:packages/icalendar, @fullcalendar/icalendar@workspace:~5.10.0":
+"@fullcalendar/icalendar@workspace:packages/icalendar, @fullcalendar/icalendar@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/icalendar@workspace:packages/icalendar"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     ical.js: ^1.4.0
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/interaction@^5.10.0, @fullcalendar/interaction@workspace:packages/interaction, @fullcalendar/interaction@workspace:~5.10.0, @fullcalendar/interaction@~5.10.0":
+"@fullcalendar/interaction@^5.10.1, @fullcalendar/interaction@workspace:packages/interaction, @fullcalendar/interaction@workspace:~5.10.1, @fullcalendar/interaction@~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/interaction@workspace:packages/interaction"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/list@^5.10.0, @fullcalendar/list@workspace:packages/list, @fullcalendar/list@workspace:~5.10.0":
+"@fullcalendar/list@^5.10.1, @fullcalendar/list@workspace:packages/list, @fullcalendar/list@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/list@workspace:packages/list"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/luxon@workspace:packages/luxon, @fullcalendar/luxon@workspace:~5.10.0":
+"@fullcalendar/luxon@workspace:packages/luxon, @fullcalendar/luxon@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/luxon@workspace:packages/luxon"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
     luxon: ^1.12.1
     tslib: ^2.1.0
@@ -3343,11 +3353,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/moment-timezone@^5.5.0, @fullcalendar/moment-timezone@workspace:packages/moment-timezone, @fullcalendar/moment-timezone@workspace:~5.10.0":
+"@fullcalendar/moment-timezone@^5.5.0, @fullcalendar/moment-timezone@workspace:packages/moment-timezone, @fullcalendar/moment-timezone@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/moment-timezone@workspace:packages/moment-timezone"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
     moment: ^2.29.1
     moment-timezone: ^0.5.31
@@ -3358,11 +3368,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/moment@^5.10.0, @fullcalendar/moment@workspace:packages/moment, @fullcalendar/moment@workspace:~5.10.0":
+"@fullcalendar/moment@^5.10.1, @fullcalendar/moment@workspace:packages/moment, @fullcalendar/moment@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/moment@workspace:packages/moment"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
     moment: ^2.29.1
     tslib: ^2.1.0
@@ -3371,25 +3381,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/premium-common@workspace:packages-premium/premium-common, @fullcalendar/premium-common@workspace:~5.10.0":
+"@fullcalendar/premium-common@workspace:packages-premium/premium-common, @fullcalendar/premium-common@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/premium-common@workspace:packages-premium/premium-common"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/react@^5.10.0, @fullcalendar/react@workspace:packages-contrib/react":
+"@fullcalendar/react@^5.10.1, @fullcalendar/react@workspace:packages-contrib/react":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/react@workspace:packages-contrib/react"
   dependencies:
     "@babel/core": ^7.0.0
     "@babel/preset-env": ^7.9.0
     "@babel/preset-react": ^7.9.4
-    "@fullcalendar/common": ~5.10.0
-    "@fullcalendar/daygrid": ~5.10.0
+    "@fullcalendar/common": ~5.10.1
+    "@fullcalendar/daygrid": ~5.10.1
     "@rollup/plugin-babel": ^5.0.0
     "@rollup/plugin-commonjs": ^11.1.0
     "@rollup/plugin-json": ^4.0.3
@@ -3427,63 +3437,63 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/resource-common@workspace:packages-premium/resource-common, @fullcalendar/resource-common@workspace:~5.10.0":
+"@fullcalendar/resource-common@workspace:packages-premium/resource-common, @fullcalendar/resource-common@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/resource-common@workspace:packages-premium/resource-common"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
-    "@fullcalendar/premium-common": "workspace:~5.10.0"
+    "@fullcalendar/premium-common": "workspace:~5.10.1"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/resource-daygrid@workspace:packages-premium/resource-daygrid, @fullcalendar/resource-daygrid@workspace:~5.10.0":
+"@fullcalendar/resource-daygrid@workspace:packages-premium/resource-daygrid, @fullcalendar/resource-daygrid@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/resource-daygrid@workspace:packages-premium/resource-daygrid"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
-    "@fullcalendar/daygrid": "workspace:~5.10.0"
-    "@fullcalendar/premium-common": "workspace:~5.10.0"
-    "@fullcalendar/resource-common": "workspace:~5.10.0"
+    "@fullcalendar/daygrid": "workspace:~5.10.1"
+    "@fullcalendar/premium-common": "workspace:~5.10.1"
+    "@fullcalendar/resource-common": "workspace:~5.10.1"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/resource-timegrid@workspace:packages-premium/resource-timegrid, @fullcalendar/resource-timegrid@workspace:~5.10.0":
+"@fullcalendar/resource-timegrid@workspace:packages-premium/resource-timegrid, @fullcalendar/resource-timegrid@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/resource-timegrid@workspace:packages-premium/resource-timegrid"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
-    "@fullcalendar/premium-common": "workspace:~5.10.0"
-    "@fullcalendar/resource-common": "workspace:~5.10.0"
-    "@fullcalendar/resource-daygrid": "workspace:~5.10.0"
-    "@fullcalendar/timegrid": "workspace:~5.10.0"
+    "@fullcalendar/premium-common": "workspace:~5.10.1"
+    "@fullcalendar/resource-common": "workspace:~5.10.1"
+    "@fullcalendar/resource-daygrid": "workspace:~5.10.1"
+    "@fullcalendar/timegrid": "workspace:~5.10.1"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/resource-timeline@^5.10.0, @fullcalendar/resource-timeline@^5.4.0, @fullcalendar/resource-timeline@^5.5.0, @fullcalendar/resource-timeline@workspace:packages-premium/resource-timeline, @fullcalendar/resource-timeline@workspace:~5.10.0":
+"@fullcalendar/resource-timeline@^5.10.1, @fullcalendar/resource-timeline@^5.4.0, @fullcalendar/resource-timeline@^5.5.0, @fullcalendar/resource-timeline@workspace:packages-premium/resource-timeline, @fullcalendar/resource-timeline@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/resource-timeline@workspace:packages-premium/resource-timeline"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
-    "@fullcalendar/premium-common": "workspace:~5.10.0"
-    "@fullcalendar/resource-common": "workspace:~5.10.0"
-    "@fullcalendar/scrollgrid": "workspace:~5.10.0"
-    "@fullcalendar/timeline": "workspace:~5.10.0"
+    "@fullcalendar/premium-common": "workspace:~5.10.1"
+    "@fullcalendar/resource-common": "workspace:~5.10.1"
+    "@fullcalendar/scrollgrid": "workspace:~5.10.1"
+    "@fullcalendar/timeline": "workspace:~5.10.1"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/rrule@workspace:packages/rrule, @fullcalendar/rrule@workspace:~5.10.0":
+"@fullcalendar/rrule@workspace:packages/rrule, @fullcalendar/rrule@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/rrule@workspace:packages/rrule"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
     rrule: ^2.6.0
     tslib: ^2.1.0
@@ -3492,41 +3502,41 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/scrollgrid@workspace:packages-premium/scrollgrid, @fullcalendar/scrollgrid@workspace:~5.10.0":
+"@fullcalendar/scrollgrid@workspace:packages-premium/scrollgrid, @fullcalendar/scrollgrid@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/scrollgrid@workspace:packages-premium/scrollgrid"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
-    "@fullcalendar/premium-common": "workspace:~5.10.0"
+    "@fullcalendar/premium-common": "workspace:~5.10.1"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/timegrid@^5.10.0, @fullcalendar/timegrid@workspace:packages/timegrid, @fullcalendar/timegrid@workspace:~5.10.0, @fullcalendar/timegrid@~5.10.0":
+"@fullcalendar/timegrid@^5.10.1, @fullcalendar/timegrid@workspace:packages/timegrid, @fullcalendar/timegrid@workspace:~5.10.1, @fullcalendar/timegrid@~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/timegrid@workspace:packages/timegrid"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
-    "@fullcalendar/daygrid": "workspace:~5.10.0"
+    "@fullcalendar/daygrid": "workspace:~5.10.1"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/timeline@^5.10.0, @fullcalendar/timeline@workspace:packages-premium/timeline, @fullcalendar/timeline@workspace:~5.10.0":
+"@fullcalendar/timeline@^5.10.1, @fullcalendar/timeline@workspace:packages-premium/timeline, @fullcalendar/timeline@workspace:~5.10.1":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/timeline@workspace:packages-premium/timeline"
   dependencies:
-    "@fullcalendar/common": "workspace:~5.10.0"
+    "@fullcalendar/common": "workspace:~5.10.1"
     "@fullcalendar/core-preact": "workspace:*"
-    "@fullcalendar/premium-common": "workspace:~5.10.0"
-    "@fullcalendar/scrollgrid": "workspace:~5.10.0"
+    "@fullcalendar/premium-common": "workspace:~5.10.1"
+    "@fullcalendar/scrollgrid": "workspace:~5.10.1"
     tslib: ^2.1.0
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/vue3@^5.10.0, @fullcalendar/vue3@workspace:packages-contrib/vue3":
+"@fullcalendar/vue3@^5.10.1, @fullcalendar/vue3@workspace:packages-contrib/vue3":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/vue3@workspace:packages-contrib/vue3"
   dependencies:
@@ -3535,8 +3545,8 @@ __metadata:
     "@babel/preset-env": ^7.8.4
     "@babel/runtime": ^7.12.1
     "@esm-bundle/chai": ^4.3.4
-    "@fullcalendar/core": ~5.10.0
-    "@fullcalendar/daygrid": ~5.10.0
+    "@fullcalendar/core": ~5.10.1
+    "@fullcalendar/daygrid": ~5.10.1
     "@rollup/plugin-alias": ^3.1.2
     "@rollup/plugin-node-resolve": ^8.4.0
     "@rollup/plugin-replace": ^2.4.2
@@ -3562,7 +3572,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fullcalendar/vue@^5.10.0, @fullcalendar/vue@workspace:packages-contrib/vue":
+"@fullcalendar/vue@^5.10.1, @fullcalendar/vue@workspace:packages-contrib/vue":
   version: 0.0.0-use.local
   resolution: "@fullcalendar/vue@workspace:packages-contrib/vue"
   dependencies:
@@ -3570,8 +3580,8 @@ __metadata:
     "@babel/plugin-transform-runtime": ^7.10.1
     "@babel/preset-env": ^7.8.4
     "@babel/runtime": ^7.12.1
-    "@fullcalendar/core": ~5.10.0
-    "@fullcalendar/daygrid": ~5.10.0
+    "@fullcalendar/core": ~5.10.1
+    "@fullcalendar/daygrid": ~5.10.1
     "@rollup/plugin-node-resolve": ^8.4.0
     "@types/estree": ^0.0.45
     "@types/node": 14.10.0
@@ -15092,17 +15102,17 @@ fsevents@~2.1.2:
     "@angular/platform-browser": ~11.0.2
     "@angular/platform-browser-dynamic": ~11.0.2
     "@angular/router": ~11.0.2
-    "@fullcalendar/core": ~5.10.0
-    "@fullcalendar/daygrid": ~5.10.0
-    "@fullcalendar/interaction": ~5.10.0
-    "@fullcalendar/timegrid": ~5.10.0
+    "@fullcalendar/core": ~5.10.1
+    "@fullcalendar/daygrid": ~5.10.1
+    "@fullcalendar/interaction": ~5.10.1
+    "@fullcalendar/timegrid": ~5.10.1
     "@types/jasmine": ~3.6.0
     "@types/jasminewd2": ~2.0.3
     "@types/node": ^12.11.1
     codelyzer: ^6.0.0
     core-js: ^3.6.2
     fast-deep-equal: ^3.1.1
-    fullcalendar-scheduler: ~5.10.0
+    fullcalendar-scheduler: ~5.10.1
     jasmine-core: ~3.6.0
     jasmine-spec-reporter: ~5.0.0
     karma: ~6.3.2
@@ -15125,17 +15135,17 @@ fsevents@~2.1.2:
   version: 0.0.0-use.local
   resolution: "fullcalendar-scheduler-tests@workspace:packages-premium/__tests__"
   dependencies:
-    "@fullcalendar/core": "workspace:~5.10.0"
-    "@fullcalendar/daygrid": "workspace:~5.10.0"
-    "@fullcalendar/interaction": "workspace:~5.10.0"
-    "@fullcalendar/list": "workspace:~5.10.0"
-    "@fullcalendar/premium-common": "workspace:~5.10.0"
-    "@fullcalendar/resource-daygrid": "workspace:~5.10.0"
-    "@fullcalendar/resource-timegrid": "workspace:~5.10.0"
-    "@fullcalendar/resource-timeline": "workspace:~5.10.0"
-    "@fullcalendar/scrollgrid": "workspace:~5.10.0"
-    "@fullcalendar/timegrid": "workspace:~5.10.0"
-    "@fullcalendar/timeline": "workspace:~5.10.0"
+    "@fullcalendar/core": "workspace:~5.10.1"
+    "@fullcalendar/daygrid": "workspace:~5.10.1"
+    "@fullcalendar/interaction": "workspace:~5.10.1"
+    "@fullcalendar/list": "workspace:~5.10.1"
+    "@fullcalendar/premium-common": "workspace:~5.10.1"
+    "@fullcalendar/resource-daygrid": "workspace:~5.10.1"
+    "@fullcalendar/resource-timegrid": "workspace:~5.10.1"
+    "@fullcalendar/resource-timeline": "workspace:~5.10.1"
+    "@fullcalendar/scrollgrid": "workspace:~5.10.1"
+    "@fullcalendar/timegrid": "workspace:~5.10.1"
+    "@fullcalendar/timeline": "workspace:~5.10.1"
     "@types/jasmine": ^3.3.12
     "@types/jasmine-jquery": ^1.5.33
     "@types/jquery": ^3.3.29
@@ -15146,24 +15156,24 @@ fsevents@~2.1.2:
   languageName: unknown
   linkType: soft
 
-"fullcalendar-scheduler@workspace:packages-premium/bundle, fullcalendar-scheduler@~5.10.0":
+"fullcalendar-scheduler@workspace:packages-premium/bundle, fullcalendar-scheduler@~5.10.1":
   version: 0.0.0-use.local
   resolution: "fullcalendar-scheduler@workspace:packages-premium/bundle"
   dependencies:
-    "@fullcalendar/adaptive": "workspace:~5.10.0"
-    "@fullcalendar/bootstrap": "workspace:~5.10.0"
-    "@fullcalendar/core": "workspace:~5.10.0"
-    "@fullcalendar/daygrid": "workspace:~5.10.0"
-    "@fullcalendar/google-calendar": "workspace:~5.10.0"
-    "@fullcalendar/interaction": "workspace:~5.10.0"
-    "@fullcalendar/list": "workspace:~5.10.0"
-    "@fullcalendar/resource-common": "workspace:~5.10.0"
-    "@fullcalendar/resource-daygrid": "workspace:~5.10.0"
-    "@fullcalendar/resource-timegrid": "workspace:~5.10.0"
-    "@fullcalendar/resource-timeline": "workspace:~5.10.0"
-    "@fullcalendar/scrollgrid": "workspace:~5.10.0"
-    "@fullcalendar/timegrid": "workspace:~5.10.0"
-    "@fullcalendar/timeline": "workspace:~5.10.0"
+    "@fullcalendar/adaptive": "workspace:~5.10.1"
+    "@fullcalendar/bootstrap": "workspace:~5.10.1"
+    "@fullcalendar/core": "workspace:~5.10.1"
+    "@fullcalendar/daygrid": "workspace:~5.10.1"
+    "@fullcalendar/google-calendar": "workspace:~5.10.1"
+    "@fullcalendar/interaction": "workspace:~5.10.1"
+    "@fullcalendar/list": "workspace:~5.10.1"
+    "@fullcalendar/resource-common": "workspace:~5.10.1"
+    "@fullcalendar/resource-daygrid": "workspace:~5.10.1"
+    "@fullcalendar/resource-timegrid": "workspace:~5.10.1"
+    "@fullcalendar/resource-timeline": "workspace:~5.10.1"
+    "@fullcalendar/scrollgrid": "workspace:~5.10.1"
+    "@fullcalendar/timegrid": "workspace:~5.10.1"
+    "@fullcalendar/timeline": "workspace:~5.10.1"
   languageName: unknown
   linkType: soft
 
@@ -15171,19 +15181,19 @@ fsevents@~2.1.2:
   version: 0.0.0-use.local
   resolution: "fullcalendar-tests@workspace:packages/__tests__"
   dependencies:
-    "@fullcalendar/bootstrap": "workspace:~5.10.0"
-    "@fullcalendar/common": "workspace:~5.10.0"
-    "@fullcalendar/core": "workspace:~5.10.0"
-    "@fullcalendar/daygrid": "workspace:~5.10.0"
-    "@fullcalendar/google-calendar": "workspace:~5.10.0"
-    "@fullcalendar/icalendar": "workspace:~5.10.0"
-    "@fullcalendar/interaction": "workspace:~5.10.0"
-    "@fullcalendar/list": "workspace:~5.10.0"
-    "@fullcalendar/luxon": "workspace:~5.10.0"
-    "@fullcalendar/moment": "workspace:~5.10.0"
-    "@fullcalendar/moment-timezone": "workspace:~5.10.0"
-    "@fullcalendar/rrule": "workspace:~5.10.0"
-    "@fullcalendar/timegrid": "workspace:~5.10.0"
+    "@fullcalendar/bootstrap": "workspace:~5.10.1"
+    "@fullcalendar/common": "workspace:~5.10.1"
+    "@fullcalendar/core": "workspace:~5.10.1"
+    "@fullcalendar/daygrid": "workspace:~5.10.1"
+    "@fullcalendar/google-calendar": "workspace:~5.10.1"
+    "@fullcalendar/icalendar": "workspace:~5.10.1"
+    "@fullcalendar/interaction": "workspace:~5.10.1"
+    "@fullcalendar/list": "workspace:~5.10.1"
+    "@fullcalendar/luxon": "workspace:~5.10.1"
+    "@fullcalendar/moment": "workspace:~5.10.1"
+    "@fullcalendar/moment-timezone": "workspace:~5.10.1"
+    "@fullcalendar/rrule": "workspace:~5.10.1"
+    "@fullcalendar/timegrid": "workspace:~5.10.1"
     "@types/jasmine": ^3.3.12
     "@types/jasmine-jquery": ^1.5.33
     "@types/jquery": ^3.3.29
@@ -15272,13 +15282,14 @@ fsevents@~2.1.2:
   version: 0.0.0-use.local
   resolution: "fullcalendar@workspace:packages/bundle"
   dependencies:
-    "@fullcalendar/bootstrap": "workspace:~5.10.0"
-    "@fullcalendar/core": "workspace:~5.10.0"
-    "@fullcalendar/daygrid": "workspace:~5.10.0"
-    "@fullcalendar/google-calendar": "workspace:~5.10.0"
-    "@fullcalendar/interaction": "workspace:~5.10.0"
-    "@fullcalendar/list": "workspace:~5.10.0"
-    "@fullcalendar/timegrid": "workspace:~5.10.0"
+    "@fullcalendar/bootstrap": "workspace:~5.10.1"
+    "@fullcalendar/bootstrap5": "workspace:~5.10.1"
+    "@fullcalendar/core": "workspace:~5.10.1"
+    "@fullcalendar/daygrid": "workspace:~5.10.1"
+    "@fullcalendar/google-calendar": "workspace:~5.10.1"
+    "@fullcalendar/interaction": "workspace:~5.10.1"
+    "@fullcalendar/list": "workspace:~5.10.1"
+    "@fullcalendar/timegrid": "workspace:~5.10.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
After discussion  about [bootstrap 5 theme](https://github.com/fullcalendar/fullcalendar/issues/6299) i propose this dev for support bootstrap 5, no breaking changes. I only add 'bootstrap5' plugin : `themeSystem: 'bootstrap5'`.

_This including changements at bootstrap 5 [(please read this)](https://getbootstrap.com/docs/5.1/migration/)_

Please, don't hesitate to review this code (unknown environment like workspaces, jsx and more..) i hope this be good and will allow to go ahead.

Best regards.