### PR TITLE
Custom headers - Possible Implementation

### DIFF
--- a/packages/common/src/event-sources/json-feed-event-source.ts
+++ b/packages/common/src/event-sources/json-feed-event-source.ts
@@ -34,7 +34,7 @@ let eventSourceDef: EventSourceDef<JsonFeedMeta> = {
   },
 
   fetch(arg, success, failure) {
-    let { meta } = arg.eventSource
+    let { meta, additionalHeaders } = arg.eventSource
     let requestParams = buildRequestParams(meta, arg.range, arg.context)
 
     requestJson(
@@ -45,6 +45,7 @@ let eventSourceDef: EventSourceDef<JsonFeedMeta> = {
       (errorMessage, xhr) => {
         failure({ message: errorMessage, xhr })
       },
+      additionalHeaders,
     )
   },
 

--- a/packages/common/src/structs/event-source-parse.ts
+++ b/packages/common/src/structs/event-source-parse.ts
@@ -18,6 +18,7 @@ const EVENT_SOURCE_REFINERS = { // does NOT include EVENT_UI_REFINERS
   // for any network-related sources
   success: identity as Identity<EventSourceSuccessResponseHandler>,
   failure: identity as Identity<EventSourceErrorResponseHandler>,
+  additionalHeaders: identity as Identity<Headers>,
 }
 
 type BuiltInEventSourceRefiners = typeof EVENT_SOURCE_REFINERS &

--- a/packages/common/src/structs/event-source-parse.ts
+++ b/packages/common/src/structs/event-source-parse.ts
@@ -77,6 +77,7 @@ export function parseEventSource(
         meta: metaRes.meta,
         ui: createEventUi(refined, context),
         extendedProps: extra,
+        additionalHeaders: refined.additionalHeaders,
       }
     }
   }

--- a/packages/common/src/structs/event-source.ts
+++ b/packages/common/src/structs/event-source.ts
@@ -32,6 +32,7 @@ export interface EventSource<Meta> {
   ui: EventUi
   success: EventSourceSuccessResponseHandler | null
   failure: EventSourceErrorResponseHandler | null
+  additionalHeaders: Headers | null
   extendedProps: Dictionary // undocumented
 }
 

--- a/packages/common/src/util/requestJson.ts
+++ b/packages/common/src/util/requestJson.ts
@@ -1,6 +1,6 @@
 import { Dictionary } from '../options'
 
-export function requestJson(method: string, url: string, params: Dictionary, successCallback, failureCallback) {
+export function requestJson(method: string, url: string, params: Dictionary, successCallback, failureCallback, additionalHeaders: Headers | null) {
   method = method.toUpperCase()
 
   let body = null
@@ -16,6 +16,12 @@ export function requestJson(method: string, url: string, params: Dictionary, suc
 
   if (method !== 'GET') {
     xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded')
+  }
+
+  if (!!additionalHeaders) {
+    additionalHeaders.forEach((value: string, key: string) => {
+      xhr.setRequestHeader(key, value);
+    });
   }
 
   xhr.onload = () => {

--- a/packages/google-calendar/src/main.ts
+++ b/packages/google-calendar/src/main.ts
@@ -38,6 +38,7 @@ let eventSourceDef: EventSourceDef<GCalMeta> = {
   fetch(arg, onSuccess, onFailure) {
     let { dateEnv, options } = arg.context
     let meta: GCalMeta = arg.eventSource.meta
+    let { additionalHeaders } = arg.eventSource;
     let apiKey = meta.googleCalendarApiKey || options.googleCalendarApiKey
 
     if (!apiKey) {
@@ -76,8 +77,9 @@ let eventSourceDef: EventSourceDef<GCalMeta> = {
         }
       }, (message, xhr) => {
         onFailure({ message, xhr })
-      })
-    }
+      },
+      additionalHeaders,
+    )}
   },
 }
 

--- a/packages/icalendar/src/main.ts
+++ b/packages/icalendar/src/main.ts
@@ -32,7 +32,7 @@ let eventSourceDef: EventSourceDef<ICalFeedMeta> = {
   },
 
   fetch(arg, onSuccess, onFailure) {
-    let { meta } = arg.eventSource
+    let { meta, additionalHeaders } = arg.eventSource
     let { internalState } = meta
 
     function handleICalEvents(errorMessage, iCalExpander: IcalExpander, xhr) {
@@ -83,6 +83,7 @@ let eventSourceDef: EventSourceDef<ICalFeedMeta> = {
           internalState.errorMessage = errorMessage
           internalState.xhr = xhr
         },
+        additionalHeaders,
       )
     } else if (!internalState.completed) {
       internalState.callbacks.push(handleICalEvents)
@@ -92,9 +93,15 @@ let eventSourceDef: EventSourceDef<ICalFeedMeta> = {
   },
 }
 
-function requestICal(url: string, successCallback: Success, failureCallback: Failure) {
+function requestICal(url: string, successCallback: Success, failureCallback: Failure, additionalHeaders: Headers | null) {
   const xhr = new XMLHttpRequest()
   xhr.open('GET', url, true)
+  if (!!additionalHeaders) {
+    additionalHeaders.forEach((value: string, key: string) => {
+      xhr.setRequestHeader(key, value);
+    });
+  }
+
   xhr.onload = () => {
     if (xhr.status >= 200 && xhr.status < 400) {
       successCallback(xhr.responseText, xhr)


### PR DESCRIPTION
I gave a stab at implementing #4627 / updates for #6683 and this seems to be working for my use case now, and lets users pass additional headers to event source configurations. This lets you set Authorization headers for JSON / iCalendar feeds.

I didn't run the tests / update tests, because I'm simply trying this out on my project as this functionality being missing is a direct blocker to work that I am currently trying to implement. Pushing this PR so the maintainers can review and take if you would like, it really seems like an easy addition with a lot of added benefits.

Should work for JSON, Google Calendar, and iCalendar feeds, but I'm only using iCalendar on my project. I'm not familiar enough with the fullcalendar source to guarantee this change works across all event sources as intended, but it is now definitely letting me pass an auth header for an ics feed.

@acerix FYI