### PR TITLE
adding backgroundColor from iCalEvent

### DIFF
--- a/packages/icalendar/package.json
+++ b/packages/icalendar/package.json
@@ -6,7 +6,7 @@
   "docs": "https://fullcalendar.io/docs/icalendar",
   "dependencies": {
     "@fullcalendar/common": "workspace:~5.10.1",
-    "ical.js": "^1.4.0",
+    "ical.js": "^1.5.0",
     "tslib": "^2.1.0"
   },
   "main": "main.cjs.js",

--- a/packages/icalendar/src/main.ts
+++ b/packages/icalendar/src/main.ts
@@ -148,6 +148,7 @@ function buildNonDateProps(iCalEvent: ICAL.Event): EventInput {
   return {
     title: iCalEvent.summary,
     url: extractEventUrl(iCalEvent),
+    backgroundColor: iCalEvent.color,
     extendedProps: {
       location: iCalEvent.location,
       organizer: iCalEvent.organizer,


### PR DESCRIPTION
As Color is a valid iCalendar attribute ([rfc7986](https://datatracker.ietf.org/doc/html/rfc7986)), adding the event backgroundColor from iCalEvent