### PR TITLE
Use HTTPS url for vue 3 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/fullcalendar/fullcalendar-example-projects.git
 [submodule "packages-contrib/vue3"]
 	path = packages-contrib/vue3
-	url = git@github.com:fullcalendar/fullcalendar-vue.git
+	url = https://github.com/fullcalendar/fullcalendar-vue.git


### PR DESCRIPTION
Hi

I got stopped by a "permission denied (publickey)" error when following the setup instructions in CONTRIBUTING.md, and found that the cause was an SSH url used by the Vue 3 submodule.  I'm guessing this was an oversight since the other submodules all use HTTPS.  With this change, it's possible to clone the repository anonymously.