### PR TITLE
Fix event time getting cut off in dayGridMonth view

### DIFF
--- a/packages/daygrid/src/styles/daygrid-event.css
+++ b/packages/daygrid/src/styles/daygrid-event.css
@@ -12,6 +12,7 @@
 
   & .fc-event-time {
     font-weight: bold;
+    flex: none;
   }
 
   & .fc-event-time,
@@ -33,6 +34,7 @@
     flex-shrink: 1;
     min-width: 0; // important for allowing to shrink all the way
     overflow: hidden;
+    text-overflow: ellipsis;
     font-weight: bold;
   }
 


### PR DESCRIPTION
In `dayGridMonth` view if the event's title is too long, the time gets cut off. It's also not clear that the event title is actually longer than what is currently displayed, and is overflowing:

<img width="492" alt="image" src="https://user-images.githubusercontent.com/12762044/157206318-b1bae9f9-e08d-45e3-ae08-af78154f6bfc.png">

This change stops the time from being cut off, and shows an ellipsis if the text is about to overflow (the latter is not as important in my opinion).
<img width="528" alt="image" src="https://user-images.githubusercontent.com/12762044/157206730-5f3c5195-17ec-441b-941c-91c8ddba8d3d.png">
