### PR TITLE
proposal: add formatting feature to weekLabel

### DIFF
--- a/packages/__tests__/src/legacy/weekLabel.ts
+++ b/packages/__tests__/src/legacy/weekLabel.ts
@@ -39,6 +39,14 @@ describe('weekText', () => { // TODO: rename file
         })
         expectWeekNumberTitle(calendar, 'YO')
       })
+
+      it('renders correctly when customized and given format string', () => {
+        let calendar = initCalendar({
+          direction: 'ltr',
+          weekText: '第{}週',
+        })
+        expectWeekNumberTitle(calendar, '第週')
+      })
     })
 
     function expectWeekNumberTitle(calendar, title) {

--- a/packages/common/src/datelib/formatting-native.ts
+++ b/packages/common/src/datelib/formatting-native.ts
@@ -285,23 +285,34 @@ function formatWeekNumber(
 ): string {
   let parts = []
 
-  if (display === 'long') {
-    parts.push(weekTextLong)
-  } else if (display === 'short' || display === 'narrow') {
-    parts.push(weekText)
+  // decide use formatter or not
+  if (weekText.indexOf("{}") < 0) {
+    // simple case
+    if (display === 'long') {
+      parts.push(weekTextLong)
+    } else if (display === 'short' || display === 'narrow') {
+      parts.push(weekText)
+    }
+  
+    if (display === 'long' || display === 'short') {
+      parts.push(' ')
+    }
+  
+    parts.push(locale.simpleNumberFormat.format(num))
+  
+    if (locale.options.direction === 'rtl') { // TODO: use control characters instead?
+      parts.reverse()
+    }  
+    return parts.join('')
+  } else {
+    // if we find "{}" template in weekText or weekTextLong, replace it with the week number.
+    const dispNum = locale.simpleNumberFormat.format(num)
+    if (display === 'long') {
+      return weekTextLong.replace("{}", dispNum)
+    } else if (display === 'short' || display === 'narrow') {
+      return weekText.replace("{}", dispNum)
+    }
   }
-
-  if (display === 'long' || display === 'short') {
-    parts.push(' ')
-  }
-
-  parts.push(locale.simpleNumberFormat.format(num))
-
-  if (locale.options.direction === 'rtl') { // TODO: use control characters instead?
-    parts.reverse()
-  }
-
-  return parts.join('')
 }
 
 // Range Formatting Utils

--- a/packages/core/src/locales/ja.ts
+++ b/packages/core/src/locales/ja.ts
@@ -11,7 +11,7 @@ export default {
     day: '日',
     list: '予定リスト',
   },
-  weekText: '週',
+  weekText: '第{}週',
   allDayText: '終日',
   moreLinkText(n) {
     return '他 ' + n + ' 件'


### PR DESCRIPTION
This PR is a proposal for weekLabel text formatting option for localization.

Motivation:

Current implementation of weekLabel can handle localization with a limiation of its label-and-number order.

i.e.
Week 1 (LTR)

Whereas in Japanese, week label is more suitable when it is rendered
number-and-label order, or label-number-label order.

i.e.
1週 (LTR)
第1週(LTR)

Google calendar renderes its weekLabel like above example.




Implementation idea:

```
This commit is a simple implementation that can parse weekLabel option with format string.

formatting rule:
- replace '{}' placeholder to week number

Given "第{}週" string in weekLabel option, it renders "第1週" text on weekLabel.

This code is tested with a limited unit test and rendering is confirmed by hand.

With its implementation, locale information file for Japanese language can be written like ja.ts.
```