### PR TITLE
fix rrule parsing: if the start date (DTSTART) includes a timezone (T…

### DIFF
--- a/packages/__tests__/src/datelib/rrule.ts
+++ b/packages/__tests__/src/datelib/rrule.ts
@@ -514,6 +514,23 @@ describe('rrule plugin', () => {
     })
   })
 
+  // https://github.com/fullcalendar/fullcalendar/issues/6932
+  it('if the start date (DTSTART) includes a timezone (TZID) the time is recognized (does not default to all day)', () => {
+    initCalendar({
+      timeZone: 'Europe/Vienna',
+      initialDate: '2022-10-29',
+      events: [
+        {
+          rrule: 'DTSTART;TZID=Europe/Vienna:20221029T150000\nRRULE:FREQ=DAILY;COUNT=2',
+        },
+      ],
+    })
+    let events = getSortedEvents()
+    expect(events.length).toBe(2)
+    expect(events[0].start).toEqualDate('2022-10-29T15:00:00')
+    expect(events[1].start).toEqualDate('2022-10-30T15:00:00')
+  })
+
   // utils
 
   function buildLocalRRuleDateStr(inputStr) { // produces strings like '20200101123030'

--- a/packages/rrule/src/main.ts
+++ b/packages/rrule/src/main.ts
@@ -152,7 +152,7 @@ function analyzeRRuleString(str) {
     isTimeZoneSpecified = isTimeZoneSpecified || result.timeZoneOffset !== null
   }
 
-  str.replace(/\b(DTSTART:)([^\n]*)/, processMatch)
+  str.replace(/\b(DTSTART(?:;TZID=[^:]+)?:)([^\n]*)/, processMatch)
   str.replace(/\b(EXDATE:)([^\n]*)/, processMatch)
   str.replace(/\b(UNTIL=)([^;\n]*)/, processMatch)
 


### PR DESCRIPTION
…ZID) the time is recognized (does not default to all day)

Would fix https://github.com/fullcalendar/fullcalendar/issues/6932.