### PR TITLE
replace "évènement" in french locales

### DIFF
--- a/packages/core/src/locales/fr-ca.ts
+++ b/packages/core/src/locales/fr-ca.ts
@@ -15,5 +15,5 @@ export default {
   weekText: 'Sem.',
   allDayText: 'Toute la journée',
   moreLinkText: 'en plus',
-  noEventsText: 'Aucun événement à afficher',
+  noEventsText: 'Aucun évènement à afficher',
 } as LocaleInput

--- a/packages/core/src/locales/fr-ch.ts
+++ b/packages/core/src/locales/fr-ch.ts
@@ -19,5 +19,5 @@ export default {
   weekText: 'Sm',
   allDayText: 'Toute la journée',
   moreLinkText: 'en plus',
-  noEventsText: 'Aucun événement à afficher',
+  noEventsText: 'Aucun évènement à afficher',
 } as LocaleInput

--- a/packages/core/src/locales/fr.ts
+++ b/packages/core/src/locales/fr.ts
@@ -19,5 +19,5 @@ export default {
   weekText: 'Sem.',
   allDayText: 'Toute la journée',
   moreLinkText: 'en plus',
-  noEventsText: 'Aucun événement à afficher',
+  noEventsText: 'Aucun évènement à afficher',
 } as LocaleInput


### PR DESCRIPTION
Updated French (and -ca and -ch) locale for a typo on the word "évènement".
While both are correct, "évènement" would be the new standard (since 1990).

Here's a article (in french) explaining all of that: https://www.lalanguefrancaise.com/orthographe/evenement-ou-evenement-orthographe

