### PR TITLE
Allow luxon3 in luxon2 package

### DIFF
--- a/packages/luxon2/package.json
+++ b/packages/luxon2/package.json
@@ -11,13 +11,13 @@
   "homepage": "https://fullcalendar.io/docs/luxon2",
   "peerDependencies": {
     "@fullcalendar/core": "~6.1.6",
-    "luxon": "^2.0.0"
+    "luxon": "^2.0.0||^3.0.0"
   },
   "devDependencies": {
     "@fullcalendar/core": "~6.1.6",
     "@fullcalendar/standard-scripts": "*",
-    "@types/luxon": "^2.0.9",
-    "luxon": "^2.0.0"
+    "@types/luxon": "^2.0.9||^3.0.0",
+    "luxon": "^2.0.0||^3.0.0"
   },
   "scripts": {
     "build": "standard-scripts pkg:build",


### PR DESCRIPTION
Allow luxon3 as a dependency to `@fullcalendar/luxon2`. Luxon3 has only one breaking change, but this should not break the `fullcalendar` integration: https://github.com/moment/luxon/blob/master/docs/upgrading.md#2x-to-30

This feature has been requested in this issue: https://github.com/fullcalendar/fullcalendar/issues/6957