### PR TITLE
Make toolbar responsive on mobile

### DIFF
--- a/packages/core/src/styles/toolbar.css
+++ b/packages/core/src/styles/toolbar.css
@@ -6,6 +6,7 @@
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
+    gap: 0.5em;
   }
 
   & .fc-toolbar.fc-header-toolbar {


### PR DESCRIPTION
closes #4638

Before:
![image](https://github.com/fullcalendar/fullcalendar/assets/34947993/9d936242-a90f-4718-a349-9d634c4a2d2c)


After:
![image](https://github.com/fullcalendar/fullcalendar/assets/34947993/e55651eb-467c-4656-a3ed-61a8ac5e3959)

