### PR TITLE
Fix translation CA

### DIFF
--- a/packages/core/src/locales/ca.ts
+++ b/packages/core/src/locales/ca.ts
@@ -10,7 +10,7 @@ export default {
     prev: 'Anterior',
     next: 'Següent',
     today: 'Avui',
-    year: 'Curs',
+    year: 'Any',
     month: 'Mes',
     week: 'Setmana',
     day: 'Dia',


### PR DESCRIPTION
Year translated into Catalan is "Any". 
"Curs" is course in english.
