### PR TITLE
Make polish locale more normal

### DIFF
--- a/packages/core/src/locales/pl.ts
+++ b/packages/core/src/locales/pl.ts
@@ -18,6 +18,6 @@ export default {
   },
   weekText: 'Tydz',
   allDayText: 'Cały dzień',
-  moreLinkText: 'więcej',
+  moreLinkText: 'Więcej',
   noEventsText: 'Brak wydarzeń do wyświetlenia',
 } as LocaleInput

--- a/packages/core/src/locales/pl.ts
+++ b/packages/core/src/locales/pl.ts
@@ -14,7 +14,7 @@ export default {
     month: 'Miesiąc',
     week: 'Tydzień',
     day: 'Dzień',
-    list: 'Plan dnia',
+    list: 'Plan',
   },
   weekText: 'Tydz',
   allDayText: 'Cały dzień',


### PR DESCRIPTION
Current name of list suggest that list can only be one day list, but there are lists of weeks etc. I also checked other languages and I mostly saw 'list' not 'day list'.