### PR TITLE
fix(#7441) - fixed selection on pressing long

### DIFF
--- a/packages/core/src/util/misc.ts
+++ b/packages/core/src/util/misc.ts
@@ -27,11 +27,13 @@ export function enableCursor() {
 
 export function preventSelection(el: HTMLElement) {
   el.style.userSelect = 'none'
+  el.style.webkitUserSelect = 'none'
   el.addEventListener('selectstart', preventDefault)
 }
 
 export function allowSelection(el: HTMLElement) {
   el.style.userSelect = ''
+  el.style.webkitUserSelect = ''
   el.removeEventListener('selectstart', preventDefault)
 }
 


### PR DESCRIPTION
#7441 

fixes this issue, when pressing long on iPad to select date or time in calendar, that all text gets marked.