### PR TITLE
fix translation 'list' in NL

### DIFF
--- a/packages/core/src/locales/nl.ts
+++ b/packages/core/src/locales/nl.ts
@@ -14,7 +14,7 @@ export default {
     month: 'Maand',
     week: 'Week',
     day: 'Dag',
-    list: 'Agenda',
+    list: 'Lijst',
   },
   allDayText: 'Hele dag',
   moreLinkText: 'extra',


### PR DESCRIPTION
`List` in Dutch isn't `Agenda` but `Lijst`
`Agenda` means `Calendar`/`Agenda` when translated into English from Dutch