### PR TITLE
Draft: Extra cell with buttons in list view

### DIFF
--- a/packages/core/src/common/EventContainer.tsx
+++ b/packages/core/src/common/EventContainer.tsx
@@ -26,6 +26,7 @@ export interface MinimalEventProps {
 
 export type EventContainerProps = ElProps & MinimalEventProps & {
   defaultGenerator: (renderProps: EventContentArg) => ComponentChild
+  extraCellGenerator: (renderProps: EventContentArg) => ComponentChild
   disableDragging?: boolean
   disableResizing?: boolean
   timeText: string
@@ -76,6 +77,7 @@ export class EventContainer extends BaseComponent<EventContainerProps> {
         generatorName="eventContent"
         customGenerator={options.eventContent}
         defaultGenerator={props.defaultGenerator}
+        extraCellGenerator={props.extraCellGenerator}
         classNameGenerator={options.eventClassNames}
         didMount={options.eventDidMount}
         willUnmount={options.eventWillUnmount}

--- a/packages/core/src/common/StandardEvent.tsx
+++ b/packages/core/src/common/StandardEvent.tsx
@@ -50,6 +50,7 @@ export class StandardEvent extends BaseComponent<StandardEventProps> {
         }}
         elAttrs={getSegAnchorAttrs(seg, context)}
         defaultGenerator={renderInnerContent}
+        extraCellGenerator={renderExtraCell}
         timeText={timeText}
       >
         {(InnerContent, eventContentArg) => (

--- a/packages/core/src/content-inject/ContentContainer.ts
+++ b/packages/core/src/content-inject/ContentContainer.ts
@@ -85,6 +85,7 @@ export type InnerContainerFunc<RenderProps> = (
   InnerContainer: InnerContainerComponent,
   renderProps: RenderProps,
   elAttrs: ElAttrs,
+  ExtraCell?: InnerContainerComponent
 ) => ComponentChildren
 
 function InnerContentInjector<RenderProps>(

--- a/packages/core/src/content-inject/ContentInjector.ts
+++ b/packages/core/src/content-inject/ContentInjector.ts
@@ -26,6 +26,7 @@ export interface ContentGeneratorProps<RenderProps> {
   generatorName: string | undefined // for informing UI-framework if `customGenerator` is undefined
   customGenerator?: CustomContentGenerator<RenderProps>
   defaultGenerator?: (renderProps: RenderProps) => ComponentChild
+  extraCellGenerator?: (renderProps: RenderProps) => ComponentChild
 }
 
 export type ContentInjectorProps<RenderProps> =

--- a/packages/list/src/ListViewEventRow.tsx
+++ b/packages/list/src/ListViewEventRow.tsx
@@ -39,12 +39,13 @@ export class ListViewEventRow extends BaseComponent<ListViewEventRowProps> {
           seg.eventRange.def.url && 'fc-event-forced-url',
         ]}
         defaultGenerator={() => renderEventInnerContent(seg, context) /* weird */}
+        extraCellGenerator={() => renderEventExtraCell(seg, context) }
         seg={seg}
         timeText=""
         disableDragging={true}
         disableResizing={true}
       >
-        {(InnerContent, eventContentArg) => (
+        {(InnerContent, eventContentArg,_not_used, ExtraCell) => (
           <Fragment>
             {buildTimeContent(seg, timeFormat, context, timeHeaderId, dateHeaderId)}
             <td aria-hidden className="fc-list-event-graphic">
@@ -59,6 +60,10 @@ export class ListViewEventRow extends BaseComponent<ListViewEventRowProps> {
               elTag="td"
               elClasses={['fc-list-event-title']}
               elAttrs={{ headers: `${eventHeaderId} ${dateHeaderId}` }}
+            />
+            <ExtraCell
+            elTag="td"
+            elClasses={['fc-list-event-extra-cell']}
             />
           </Fragment>
         )}
@@ -75,6 +80,20 @@ function renderEventInnerContent(seg: Seg, context: ViewContext) {
       {seg.eventRange.def.title}
     </a>
   )
+}
+
+function renderEventExtraCell(seg: Seg, context: ViewContext) {
+    const retrieveElementFromSeg = (seg: Seg) => {
+        return undefined;
+    };
+    const element: HTMLElement = retrieveElementFromSeg(seg)
+    let interactiveAttrs = getSegAnchorAttrs(seg, context)
+    for (let key in interactiveAttrs) {
+        element.setAttribute(key, interactiveAttrs[key])
+    }
+    return (
+        element
+    )
 }
 
 function buildTimeContent(

--- a/packages/list/src/ListViewHeaderRow.tsx
+++ b/packages/list/src/ListViewHeaderRow.tsx
@@ -59,7 +59,7 @@ export class ListViewHeaderRow extends BaseComponent<ListViewHeaderRowProps> {
         willUnmount={options.dayHeaderWillUnmount}
       >
         {(InnerContent) => ( // TODO: force-hide top border based on :first-child
-          <th scope="colgroup" colSpan={3} id={cellId} aria-labelledby={textId}>
+          <th scope="colgroup" colSpan={4} id={cellId} aria-labelledby={textId}>
             <InnerContent
               elTag="div"
               elClasses={[


### PR DESCRIPTION
Hello,

I'd like to enhance list view with extra cell containing buttons that could be used to manipulate event. This would require to allow passing  optional `HTMLElement` (or some other interface to be framework agnostic ?) which then could be rendered in extra cell. Please refer to screenshot attached

<img width="1680" alt="Screenshot 2023-10-10 at 20 46 57" src="https://github.com/fullcalendar/fullcalendar/assets/27929367/7bb3b20d-1c83-44c3-adbf-df2c85cc87b6">

Could you please assist on how this idea can be developed? I did some initial draft but got really confused how to make it agnostic and what should be the API to allow rendering custom components in extra table cell.

I assume this requires change in event struct https://github.com/fullcalendar/fullcalendar/blob/main/packages/core/src/structs/event-source-parse.ts#L34 to allow pass `HTMLElement`?
 
