### PR TITLE
Provide drag start and end events for external draggable

### DIFF
--- a/packages/interaction/src/interactions-external/ExternalDraggable.ts
+++ b/packages/interaction/src/interactions-external/ExternalDraggable.ts
@@ -1,9 +1,11 @@
 import { BASE_OPTION_DEFAULTS, PointerDragEvent } from '@fullcalendar/core/internal'
 import { FeaturefulElementDragging } from '../dnd/FeaturefulElementDragging.js'
-import { ExternalElementDragging, DragMetaGenerator } from './ExternalElementDragging.js'
+import { ExternalElementDragging, DragMetaGenerator, DragEventStart, DragEventEnd } from './ExternalElementDragging.js'
 
 export interface ExternalDraggableSettings {
   eventData?: DragMetaGenerator
+  eventDragStart?: DragEventStart
+  eventDragEnd?: DragEventEnd
   itemSelector?: string
   minDistance?: number
   longPressDelay?: number
@@ -36,7 +38,7 @@ export class ExternalDraggable {
     dragging.emitter.on('pointerdown', this.handlePointerDown)
     dragging.emitter.on('dragstart', this.handleDragStart)
 
-    new ExternalElementDragging(dragging, settings.eventData) // eslint-disable-line no-new
+    new ExternalElementDragging(dragging, settings.eventData, settings.eventDragStart, settings.eventDragEnd) // eslint-disable-line no-new
   }
 
   handlePointerDown = (ev: PointerDragEvent) => {

--- a/packages/interaction/src/interactions-external/ExternalElementDragging.ts
+++ b/packages/interaction/src/interactions-external/ExternalElementDragging.ts
@@ -123,7 +123,7 @@ export class ExternalElementDragging {
       this.receivingContext = receivingContext
       this.droppableEvent = droppableEvent
     }
-    if(this.suppliedDragEventStart !== null){
+    if(this.suppliedDragEventStart !== null) {
       this.suppliedDragEventStart(this.hitDragging.dragging.mirror.getMirrorEl())
     }
   }
@@ -182,7 +182,7 @@ export class ExternalElementDragging {
 
     this.receivingContext = null
     this.droppableEvent = null
-    if(this.suppliedDragEventEnd !== null){
+    if(this.suppliedDragEventEnd !== null) {
       this.suppliedDragEventEnd()
     }
   }


### PR DESCRIPTION
Hello @arshaw,

I implemented support for the drag start and end events for external draggable elements (#7431).
My use case is that I have a table with a different layout then the fc-event elements should have. I want to allow users to drag the table rows into the calender. This feature allows me to manipulate the mirror element after the drag start to match the correct fc-event styling.

An option to generate the mirror element would go to far or would that be useful too?

I did not compile the code oder added the options to the documentation.
I'm looking forward to your feedback.

~ Marius