### PR TITLE
Locale: cs word for Today fixed

### DIFF
--- a/packages/core/src/locales/cs.ts
+++ b/packages/core/src/locales/cs.ts
@@ -9,7 +9,7 @@ export default {
   buttonText: {
     prev: 'Dříve',
     next: 'Později',
-    today: 'Nyní',
+    today: 'Dnes',
     year: 'Rok',
     month: 'Měsíc',
     week: 'Týden',


### PR DESCRIPTION
A tiny change fixing the Czech translation for the word "today". It used to be translated as "Nyní" which means now. "Dnes" means today. This change makes sense in the context of the option to jump to current day in any view. 