### PR TITLE
Update Popover.tsx

### DIFF
--- a/packages/core/src/common/Popover.tsx
+++ b/packages/core/src/common/Popover.tsx
@@ -118,14 +118,15 @@ export class Popover extends BaseComponent<PopoverProps> {
       let popoverLeft = isRtl ? alignmentRect.right - popoverDims.width : alignmentRect.left
 
       // constrain
+      let origin = rootEl.offsetParent.getBoundingClientRect()
+      
       popoverTop = Math.max(popoverTop, PADDING_FROM_VIEWPORT)
-      popoverLeft = Math.min(popoverLeft, document.documentElement.clientWidth - PADDING_FROM_VIEWPORT - popoverDims.width)
+      popoverLeft = Math.min(popoverLeft, origin.width + origin.left - popoverDims.width)
       popoverLeft = Math.max(popoverLeft, PADDING_FROM_VIEWPORT)
 
-      let origin = rootEl.offsetParent.getBoundingClientRect()
       applyStyle(rootEl, {
         top: popoverTop - origin.top,
-        left: popoverLeft - origin.left,
+        left: popoverLeft - origin.left + rootEl.offsetParent.scrollLeft,
       })
     }
   }


### PR DESCRIPTION
I fixed bug of popover being sometimes off boundry. Firstly when table is scrollable on x axis it wasn't taken in account. Secondly, the calculation for border was sometimes off, I am not sure how it was inteded to work but I changed it a bit so now it is calculated from parent width and I removed padding. You might want to double check my solution, not sure if it is universal but imo it should be. I needed to make that change for my usecase at least.