### PR TITLE
Update @fullcalendar/google-calendar to accept access token

### DIFF
--- a/packages/google-calendar/src/event-source-refiners.ts
+++ b/packages/google-calendar/src/event-source-refiners.ts
@@ -2,6 +2,7 @@ import { identity, Identity, Dictionary } from '@fullcalendar/core/internal'
 
 export const EVENT_SOURCE_REFINERS = {
   googleCalendarApiKey: String, // TODO: rename with no prefix?
+  googleCalendarAccessToken: String,
   googleCalendarId: String,
   googleCalendarApiBase: String,
   extraParams: identity as Identity<Dictionary | (() => Dictionary)>,

--- a/packages/google-calendar/src/options-refiners.ts
+++ b/packages/google-calendar/src/options-refiners.ts
@@ -1,4 +1,5 @@
 
 export const OPTION_REFINERS = {
   googleCalendarApiKey: String,
+  googleCalendarAccessToken: String,
 }

--- a/tests/manual/google-calendar-access-token.html
+++ b/tests/manual/google-calendar-access-token.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8' />
+<script src='../../packages/core/dist/index.global.js'></script>
+<script src='../../packages/daygrid/dist/index.global.js'></script>
+<script src='../../packages/list/dist/index.global.js'></script>
+<script src='../../packages/google-calendar/dist/index.global.js'></script>
+<script>
+
+  document.addEventListener('DOMContentLoaded', function() {
+    var calendarEl = document.getElementById('calendar');
+
+    var calendar = new FullCalendar.Calendar(calendarEl, {
+
+      headerToolbar: {
+        left: 'prev,next today',
+        center: 'title',
+        right: 'dayGridMonth,listYear'
+      },
+
+      displayEventTime: false, // don't show the time column in list view
+
+      // To make your own access token, follow instructions below:
+      // 1. Navigate to https://developers.google.com/oauthplayground/
+      // 2. Find the scope category: Google Calendar API v3
+      // 3. Select scope: https://www.googleapis.com/auth/calendar
+      // 4. Press "Authorize API" button
+      // 5. Allow to access Google Calendar
+      // 6. Press "Exchange authorization code for tokens" button
+      // 7. Copy access token and paste below
+      googleCalendarAccessToken: 'ACCESS_TOKEN',
+
+      // US Holidays
+      events: 'en.usa#holiday@group.v.calendar.google.com',
+
+      eventClick: function(arg) {
+        // opens events in a popup window
+        window.open(arg.event.url, 'google-calendar-event', 'width=700,height=600');
+
+        arg.jsEvent.preventDefault() // don't navigate in main tab
+      },
+
+      loading: function(bool) {
+        document.getElementById('loading').style.display =
+          bool ? 'block' : 'none';
+      }
+
+    });
+
+    calendar.render();
+  });
+
+</script>
+<style>
+
+  body {
+    margin: 40px 10px;
+    padding: 0;
+    font-family: Arial, Helvetica Neue, Helvetica, sans-serif;
+    font-size: 14px;
+  }
+
+  #loading {
+    display: none;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
+
+  #calendar {
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+</style>
+</head>
+<body>
+
+  <div id='loading'>loading...</div>
+
+  <div id='calendar'></div>
+
+</body>
+</html>


### PR DESCRIPTION
This solves issue https://github.com/fullcalendar/fullcalendar/issues/7738. If neither an API key or access token is provided, Use same behavior where the error callback is called. 