### PR TITLE
Fix: Include extendedProps in iCalendar Events to Allow Custom Properties

### DIFF
--- a/packages/icalendar/src/event-source-def.ts
+++ b/packages/icalendar/src/event-source-def.ts
@@ -1,5 +1,5 @@
 import { EventInput } from '@fullcalendar/core'
-import { EventSourceDef, DateRange, addDays } from '@fullcalendar/core/internal'
+import { EventSourceDef, DateRange, addDays, Dictionary } from '@fullcalendar/core/internal'
 import * as ICAL from 'ical.js'
 import { IcalExpander } from './ical-expander/IcalExpander.js'
 
@@ -55,7 +55,7 @@ export const eventSourceDef: EventSourceDef<ICalFeedMeta> = {
     internalState.iCalExpanderPromise.then(
       (iCalExpander) => {
         successCallback({
-          rawEvents: expandICalEvents(iCalExpander, arg.range),
+          rawEvents: expandICalEvents(iCalExpander, arg.range, arg.eventSource.extendedProps),
           response: internalState.response,
         })
       },
@@ -64,7 +64,7 @@ export const eventSourceDef: EventSourceDef<ICalFeedMeta> = {
   },
 }
 
-function expandICalEvents(iCalExpander: IcalExpander, range: DateRange): EventInput[] {
+function expandICalEvents(iCalExpander: IcalExpander, range: DateRange, extendedProps: Dictionary): EventInput[] {
   // expand the range. because our `range` is timeZone-agnostic UTC
   // or maybe because ical.js always produces dates in local time? i forget
   let rangeStart = addDays(range.start, -1)
@@ -79,7 +79,7 @@ function expandICalEvents(iCalExpander: IcalExpander, range: DateRange): EventIn
   // single events
   for (let iCalEvent of iCalRes.events) {
     expanded.push({
-      ...buildNonDateProps(iCalEvent),
+      ...buildNonDateProps(iCalEvent, extendedProps),
       start: iCalEvent.startDate.toString(),
       end: (specifiesEnd(iCalEvent) && iCalEvent.endDate)
         ? iCalEvent.endDate.toString()
@@ -91,7 +91,7 @@ function expandICalEvents(iCalExpander: IcalExpander, range: DateRange): EventIn
   for (let iCalOccurence of iCalRes.occurrences) {
     let iCalEvent = iCalOccurence.item
     expanded.push({
-      ...buildNonDateProps(iCalEvent),
+      ...buildNonDateProps(iCalEvent, extendedProps),
       start: iCalOccurence.startDate.toString(),
       end: (specifiesEnd(iCalEvent) && iCalOccurence.endDate)
         ? iCalOccurence.endDate.toString()
@@ -102,11 +102,12 @@ function expandICalEvents(iCalExpander: IcalExpander, range: DateRange): EventIn
   return expanded
 }
 
-function buildNonDateProps(iCalEvent: ICAL.Event): EventInput {
+function buildNonDateProps(iCalEvent: ICAL.Event, extendedProps: Dictionary): EventInput {
   return {
     title: iCalEvent.summary,
     url: extractEventUrl(iCalEvent),
     extendedProps: {
+      ...extendedProps,
       location: iCalEvent.location,
       organizer: iCalEvent.organizer,
       description: iCalEvent.description,


### PR DESCRIPTION
### Description of Changes

This pull request addresses an issue in FullCalendar when handling iCalendar feeds. According to the official FullCalendar documentation, non-standard fields in event objects are moved into the `extendedProps` hash during event parsing, allowing developers to add custom properties to events. However, in the current implementation for iCalendar feeds, it was not possible to include additional custom properties in `extendedProps`. Only specific values such as `location`, `organizer`, and `description` were allowed, preventing developers from adding their own custom properties.

To resolve this, I modified the `expandICalEvents` and `buildNonDateProps` functions so that any `extendedProps` passed as part of the event source configuration are merged into the event object. This allows custom properties provided via `extendedProps` to be included in the event object for iCalendar feeds.

### Summary of Changes
- Updated `expandICalEvents` to pass the `extendedProps` received from the event source configuration when building each event object.
- Modified `buildNonDateProps` to ensure that the `extendedProps` are properly merged with the iCalendar event’s `location`, `organizer`, and `description` fields, so custom properties can be added to the event.

This fix ensures that developers can now include their own custom properties in `extendedProps` when working with iCalendar feeds, as described in the FullCalendar documentation.