### PR TITLE
Just return "Terminübersicht" in viewHint()

### DIFF
--- a/packages/core/src/locales/de.ts
+++ b/packages/core/src/locales/de.ts
@@ -44,6 +44,9 @@ export default {
     },
   },
   viewHint(buttonText) {
+    if(buttonText === "Terminübersicht") {
+        return buttonText;
+    }
     // → Tagesansicht, Wochenansicht, Monatsansicht, Jahresansicht
     const glue = buttonText === 'Woche' ? 'n' : buttonText === 'Monat' ? 's' : 'es'
     return buttonText + glue + 'ansicht'


### PR DESCRIPTION
The *glue* with the suffix `ansicht` does not work for `Terminübersicht`.