### PR TITLE
Update sr localization to be latin - sr-cyrl already exists for cyrilic

### DIFF
--- a/packages/core/src/locales/sr.ts
+++ b/packages/core/src/locales/sr.ts
@@ -1,7 +1,8 @@
 import { LocaleInput } from '../index.js'
 
 export default {
-  code: 'sr',
+  // sr-Latn is latin, for cyrilic use sr-cyrl
+  code: 'sr-Latn', // https://localizely.com/locale-code/sr-Latn-RS/
   week: {
     dow: 1, // Monday is the first day of the week.
     doy: 7, // The week that contains Jan 1st is the first week of the year.


### PR DESCRIPTION
Serbian language uses both Latin and Cyrilic script - Since sr-cyrl already exists for cyrilic script sr should be latin - so update sr to use latin letters for system localization