### PR TITLE
feature: insert styleSheet when switching between micro-applications after keep-alive is enabled

### DIFF
--- a/packages/core/src/styleUtils.ts
+++ b/packages/core/src/styleUtils.ts
@@ -21,7 +21,7 @@ export function ensureElHasStyles(el: HTMLElement): void {
 function registerStylesRoot(rootNode: ParentNode): void {
   let styleEl: HTMLStyleElement = styleEls.get(rootNode)
 
-  if (!styleEl || !styleEl.isConnected) {
+  if (!styleEl || !styleEl.isConnected || !styleEl.sheet.cssRules.length) {
     styleEl = rootNode.querySelector('style[data-fullcalendar]')
 
     if (!styleEl) {


### PR DESCRIPTION
The styleSheet in style[data-fullcalendar] will be lost when switching between micro-applications after keep-alive is enabled。
So the styleSheet should be reinserted when styleEl.sheet.cssRules.length is empty