### PR TITLE
add fc-scroller class in computeScrollbarWidths for customizable scrollbar

### DIFF
--- a/packages/core/src/util/scrollbar-width.ts
+++ b/packages/core/src/util/scrollbar-width.ts
@@ -19,6 +19,7 @@ function computeScrollbarWidths(): ScrollbarWidths {
   el.style.position = 'absolute'
   el.style.top = '-9999px'
   el.style.left = '-9999px'
+  el.className= 'fc-scroller'
   document.body.appendChild(el)
   let res = computeScrollbarWidthsForEl(el)
   document.body.removeChild(el)


### PR DESCRIPTION
This pull request adds a new line in the computeScrollbarWidths function to assign the fc-scroller class to the temporary element created for scrollbar measurement. 

This makes it easier to target the scrollbar element for customization.


So that, you can customize scrollbar in fullcalendar using below css.
```css
.fc-scroller {
  @apply pr-0;
}
.fc-scroller::-webkit-scrollbar {
  width: 6px;
  height: 6px;
}
.fc-scroller::-webkit-scrollbar-track {
  @apply mx-2 my-1 bg-transparent;
}
.fc-scroller::-webkit-scrollbar-thumb {
  @apply bg-border/60 hover:bg-border/80 active:bg-border rounded;
}
```