### PR TITLE
Fixed `droppable: false` not disabling external event dragging

### DIFF
--- a/packages/interaction/src/interactions-external/ExternalElementDragging.ts
+++ b/packages/interaction/src/interactions-external/ExternalElementDragging.ts
@@ -79,7 +79,7 @@ export class ExternalElementDragging {
     if (hit) {
       receivingContext = hit.context
 
-      if (this.canDropElOnCalendar(ev.subjectEl as HTMLElement, receivingContext)) {
+      if (this.canDropElOnCalendar(ev.subjectEl as HTMLElement, receivingContext) && receivingContext.options.droppable) {
         droppableEvent = computeEventForDateSpan(
           hit.dateSpan,
           this.dragMeta!,


### PR DESCRIPTION
Fixes #7776
I have tested this as a monkeypatch on `@fullcalendar/interaction` version `5.8.0`, wanted to properly test this but I ran into #7178 and don't have a Linux system available at the moment unfortunately.