### PR TITLE
Changed <a> tag to <span> of class 'fc-col-header-cell-cushion' for SEO opt…

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,0 @@
-{
-  "recommendations": [
-    "dbaeumer.vscode-eslint"
-  ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  }
-}

--- a/packages/core/src/common/TableDateCell.tsx
+++ b/packages/core/src/common/TableDateCell.tsx
@@ -79,7 +79,7 @@ export class TableDateCell extends BaseComponent<TableDateCellProps> {
           <div className="fc-scrollgrid-sync-inner">
             {!dayMeta.isDisabled && (
               <InnerContainer
-                elTag="a"
+                elTag="span"
                 elAttrs={navLinkAttrs}
                 elClasses={[
                   'fc-col-header-cell-cushion',

--- a/packages/core/src/common/TableDowCell.tsx
+++ b/packages/core/src/common/TableDowCell.tsx
@@ -67,7 +67,7 @@ export class TableDowCell extends BaseComponent<TableDowCellProps> {
         {(InnerContent) => (
           <div className="fc-scrollgrid-sync-inner">
             <InnerContent
-              elTag="a"
+              elTag="span"
               elClasses={[
                 'fc-col-header-cell-cushion',
                 props.isSticky && 'fc-sticky',

--- a/packages/core/src/styles/col-header.css
+++ b/packages/core/src/styles/col-header.css
@@ -1,9 +1,8 @@
-
 .fc {
 
-  & .fc-col-header-cell-cushion {
-    display: inline-block; // x-browser for when sticky (when multi-tier header)
-    padding: 2px 4px;
-  }
+    & .fc-col-header-cell-cushion {
+        display: inline-block; // x-browser for when sticky (when multi-tier header)
+        padding: 2px 4px;
+    }
 
 }


### PR DESCRIPTION
Hello, after using **fullcalendar-react**, I obtained a very nice calendar, but a reduce in score of SEO on Google page speed insights, due to the fact that links should define the **href** attribute, which is not done in **fullcalendar**.

Here I simply changed the <a> tag to <span> since it is an inline element.