### PR TITLE
fix(interaction): apply touch-action manipulation in DateClicking to …

### DIFF
--- a/packages/interaction/src/interactions/DateClicking.ts
+++ b/packages/interaction/src/interactions/DateClicking.ts
@@ -1,15 +1,18 @@
-import { ViewApi, DatePointApi } from '@fullcalendar/core'
+import { ViewApi, DatePointApi } from '@fullcalendar/core';
 import {
-  PointerDragEvent, Interaction, InteractionSettings, interactionSettingsToStore,
-} from '@fullcalendar/core/internal'
-import { FeaturefulElementDragging } from '../dnd/FeaturefulElementDragging.js'
-import { HitDragging, isHitsEqual } from './HitDragging.js'
-import { buildDatePointApiWithContext } from '../utils.js'
+  PointerDragEvent,
+  Interaction,
+  InteractionSettings,
+  interactionSettingsToStore,
+} from '@fullcalendar/core/internal';
+import { FeaturefulElementDragging } from '../dnd/FeaturefulElementDragging.js';
+import { HitDragging, isHitsEqual } from './HitDragging.js';
+import { buildDatePointApiWithContext } from '../utils.js';
 
 export interface DateClickArg extends DatePointApi {
-  dayEl: HTMLElement
-  jsEvent: MouseEvent
-  view: ViewApi
+  dayEl: HTMLElement;
+  jsEvent: MouseEvent;
+  view: ViewApi;
 }
 
 /*
@@ -17,54 +20,57 @@ Monitors when the user clicks on a specific date/time of a component.
 A pointerdown+pointerup on the same "hit" constitutes a click.
 */
 export class DateClicking extends Interaction {
-  dragging: FeaturefulElementDragging
-  hitDragging: HitDragging
+  dragging: FeaturefulElementDragging;
+  hitDragging: HitDragging;
 
   constructor(settings: InteractionSettings) {
-    super(settings)
+    super(settings);
+
+    settings.el.style.touchAction = 'manipulation';
 
     // we DO want to watch pointer moves because otherwise finalHit won't get populated
-    this.dragging = new FeaturefulElementDragging(settings.el)
-    this.dragging.autoScroller.isEnabled = false
+    this.dragging = new FeaturefulElementDragging(settings.el);
+    this.dragging.autoScroller.isEnabled = false;
 
-    let hitDragging = this.hitDragging = new HitDragging(this.dragging, interactionSettingsToStore(settings))
-    hitDragging.emitter.on('pointerdown', this.handlePointerDown)
-    hitDragging.emitter.on('dragend', this.handleDragEnd)
+    let hitDragging = (this.hitDragging = new HitDragging(
+      this.dragging,
+      interactionSettingsToStore(settings)
+    ));
+    hitDragging.emitter.on('pointerdown', this.handlePointerDown);
+    hitDragging.emitter.on('dragend', this.handleDragEnd);
   }
 
   destroy() {
-    this.dragging.destroy()
+    this.dragging.destroy();
   }
 
   handlePointerDown = (pev: PointerDragEvent) => {
-    let { dragging } = this
-    let downEl = pev.origEvent.target as HTMLElement
+    let { dragging } = this;
+    let downEl = pev.origEvent.target as HTMLElement;
 
     // do this in pointerdown (not dragend) because DOM might be mutated by the time dragend is fired
-    dragging.setIgnoreMove(
-      !this.component.isValidDateDownEl(downEl),
-    )
-  }
+    dragging.setIgnoreMove(!this.component.isValidDateDownEl(downEl));
+  };
 
   // won't even fire if moving was ignored
   handleDragEnd = (ev: PointerDragEvent) => {
-    let { component } = this
-    let { pointer } = this.dragging
+    let { component } = this;
+    let { pointer } = this.dragging;
 
     if (!pointer.wasTouchScroll) {
-      let { initialHit, finalHit } = this.hitDragging
+      let { initialHit, finalHit } = this.hitDragging;
 
       if (initialHit && finalHit && isHitsEqual(initialHit, finalHit)) {
-        let { context } = component
+        let { context } = component;
         let arg: DateClickArg = {
           ...buildDatePointApiWithContext(initialHit.dateSpan, context),
           dayEl: initialHit.dayEl,
           jsEvent: ev.origEvent as MouseEvent,
           view: context.viewApi || context.calendarApi.view,
-        }
+        };
 
-        context.emitter.trigger('dateClick', arg)
+        context.emitter.trigger('dateClick', arg);
       }
     }
-  }
+  };
 }


### PR DESCRIPTION
…prevent ghost mobile clicks

```js
constructor(settings: InteractionSettings) {
    super(settings);
    // Only that line has been added.
    settings.el.style.touchAction = 'manipulation';

```

In DateClicking.constructor, set `settings.el.style.touchAction = 'manipulation'` to disable the browser’s synthetic click after touch events and eliminate ghost clicks on mobile devices.


### Before
![1111111111](https://github.com/user-attachments/assets/c7cdb173-cb1d-4f94-be67-8e92367fa41f)

### After
![222222222](https://github.com/user-attachments/assets/15f19269-1472-4e74-8c68-ed7f8c556835)

