### PR TITLE
Add daygrid-overlaps plugin with proportional multi-day layout

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  }
+	"source.fixAll.eslint": "explicit"
+}
 }

--- a/packages/daygrid-overlaps/.eslintrc.cjs
+++ b/packages/daygrid-overlaps/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: require.resolve('@fullcalendar-scripts/standard/config/eslint.pkg.browser.cjs'),
+}

--- a/packages/daygrid-overlaps/README.md
+++ b/packages/daygrid-overlaps/README.md
@@ -1,0 +1,32 @@
+
+# FullCalendar Day Grid Plugin
+
+Display events on a [month view](https://fullcalendar.io/docs/month-view) or ["day grid" view](https://fullcalendar.io/docs/daygrid-view)
+
+## Installation
+
+Install the necessary packages:
+
+```sh
+npm install @fullcalendar/core @fullcalendar/daygrid
+```
+
+## Usage
+
+Instantiate a Calendar with the necessary plugin:
+
+```js
+import { Calendar } from '@fullcalendar/core'
+import dayGridPlugin from '@fullcalendar/daygrid'
+
+const calendarEl = document.getElementById('calendar')
+const calendar = new Calendar(calendarEl, {
+  plugins: [dayGridPlugin],
+  initialView: 'dayGridMonth',
+  events: [
+    { title: 'Meeting', start: new Date() }
+  ]
+})
+
+calendar.render()
+```

--- a/packages/daygrid-overlaps/package.json
+++ b/packages/daygrid-overlaps/package.json
@@ -1,0 +1,52 @@
+{
+	"name": "@fullcalendar/daygrid-overlaps",
+	"version": "6.1.19",
+	"title": "FullCalendar Day Grid Plugin",
+	"description": "Display events on a month view or \"day grid\" view",
+	"homepage": "https://fullcalendar.io/docs/month-view",
+	"keywords": [
+		"month",
+		"month-view"
+	],
+	"peerDependencies": {
+		"@fullcalendar/core": "~6.1.19"
+	},
+	"devDependencies": {
+		"@fullcalendar/core": "~6.1.19",
+		"@fullcalendar-scripts/standard": "*"
+	},
+	"scripts": {
+		"build": "standard-scripts pkg:build",
+		"clean": "standard-scripts pkg:clean",
+		"lint": "eslint ."
+	},
+	"type": "module",
+	"main": "src/index.ts",
+	"types": "src/index.ts",
+	"tsConfig": {
+		"extends": "@fullcalendar-scripts/standard/config/tsconfig.browser.json",
+		"compilerOptions": {
+			"rootDir": "./src",
+			"outDir": "./dist/.tsout"
+		},
+		"include": [
+			"./src/**/*"
+		]
+	},
+	"buildConfig": {
+		"exports": {
+			".": {
+				"iife": true
+			},
+			"./internal": {}
+		},
+		"iifeGlobals": {
+			".": "FullCalendar.DayGrid.Overlaps",
+			"./internal": "FullCalendar.DayGrid.Overlaps.Internal"
+		}
+	},
+	"publishConfig": {
+		"directory": "./dist",
+		"linkDirectory": true
+	}
+}

--- a/packages/daygrid-overlaps/src/DayTable.tsx
+++ b/packages/daygrid-overlaps/src/DayTable.tsx
@@ -1,0 +1,72 @@
+import { Duration, CssDimValue } from '@fullcalendar/core'
+import {
+  EventStore,
+  EventUiHash,
+  DateSpan,
+  EventInteractionState,
+  DayTableModel,
+  DateComponent,
+  ViewContext,
+  DateProfile,
+} from '@fullcalendar/core/internal'
+import {
+  createElement,
+  createRef,
+  VNode,
+  RefObject,
+} from '@fullcalendar/core/preact'
+import { Table } from './Table.js'
+import { DayTableSlicer } from './DayTableSlicer.js'
+
+export interface DayTableProps {
+  dateProfile: DateProfile,
+  dayTableModel: DayTableModel
+  nextDayThreshold: Duration
+  businessHours: EventStore
+  eventStore: EventStore
+  eventUiBases: EventUiHash
+  dateSelection: DateSpan | null
+  eventSelection: string
+  eventDrag: EventInteractionState | null
+  eventResize: EventInteractionState | null
+  colGroupNode: VNode
+  tableMinWidth: CssDimValue
+  renderRowIntro?: () => VNode
+  dayMaxEvents: boolean | number
+  dayMaxEventRows: boolean | number
+  expandRows: boolean
+  showWeekNumbers: boolean
+  headerAlignElRef?: RefObject<HTMLElement> // for more popover alignment
+  clientWidth: number | null
+  clientHeight: number | null
+  forPrint: boolean
+}
+
+export class DayTable extends DateComponent<DayTableProps, ViewContext> {
+  private slicer = new DayTableSlicer()
+  private tableRef = createRef<Table>()
+
+  render() {
+    let { props, context } = this
+
+    return (
+      <Table
+        ref={this.tableRef}
+        {...this.slicer.sliceProps(props, props.dateProfile, props.nextDayThreshold, context, props.dayTableModel)}
+        dateProfile={props.dateProfile}
+        cells={props.dayTableModel.cells}
+        colGroupNode={props.colGroupNode}
+        tableMinWidth={props.tableMinWidth}
+        renderRowIntro={props.renderRowIntro}
+        dayMaxEvents={props.dayMaxEvents}
+        dayMaxEventRows={props.dayMaxEventRows}
+        showWeekNumbers={props.showWeekNumbers}
+        expandRows={props.expandRows}
+        headerAlignElRef={props.headerAlignElRef}
+        clientWidth={props.clientWidth}
+        clientHeight={props.clientHeight}
+        forPrint={props.forPrint}
+      />
+    )
+  }
+}

--- a/packages/daygrid-overlaps/src/DayTableSlicer.ts
+++ b/packages/daygrid-overlaps/src/DayTableSlicer.ts
@@ -1,0 +1,10 @@
+import { DayTableModel, DateRange, Slicer } from '@fullcalendar/core/internal'
+import { TableSeg } from './TableSeg.js'
+
+export class DayTableSlicer extends Slicer<TableSeg, [DayTableModel]> {
+  forceDayIfListItem = true
+
+  sliceRange(dateRange: DateRange, dayTableModel: DayTableModel): TableSeg[] {
+    return dayTableModel.sliceRange(dateRange)
+  }
+}

--- a/packages/daygrid-overlaps/src/DayTableView.tsx
+++ b/packages/daygrid-overlaps/src/DayTableView.tsx
@@ -1,0 +1,74 @@
+import {
+  DayHeader,
+  DateProfileGenerator,
+  DateProfile,
+  memoize,
+  DaySeriesModel,
+  DayTableModel,
+  ChunkContentCallbackArgs,
+} from '@fullcalendar/core/internal'
+import { createElement, createRef } from '@fullcalendar/core/preact'
+import { TableView } from './TableView.js'
+import { DayTable } from './DayTable.js'
+
+export class DayTableView extends TableView {
+  private buildDayTableModel = memoize(buildDayTableModel)
+  private headerRef = createRef<DayHeader>()
+  private tableRef = createRef<DayTable>()
+
+  render() {
+    let { options, dateProfileGenerator } = this.context
+    let { props } = this
+    let dayTableModel = this.buildDayTableModel(props.dateProfile, dateProfileGenerator)
+
+    let headerContent = options.dayHeaders && (
+      <DayHeader
+        ref={this.headerRef}
+        dateProfile={props.dateProfile}
+        dates={dayTableModel.headerDates}
+        datesRepDistinctDays={dayTableModel.rowCnt === 1}
+      />
+    )
+
+    let bodyContent = (contentArg: ChunkContentCallbackArgs) => (
+      <DayTable
+        ref={this.tableRef}
+        dateProfile={props.dateProfile}
+        dayTableModel={dayTableModel}
+        businessHours={props.businessHours}
+        dateSelection={props.dateSelection}
+        eventStore={props.eventStore}
+        eventUiBases={props.eventUiBases}
+        eventSelection={props.eventSelection}
+        eventDrag={props.eventDrag}
+        eventResize={props.eventResize}
+        nextDayThreshold={options.nextDayThreshold}
+        colGroupNode={contentArg.tableColGroupNode}
+        tableMinWidth={contentArg.tableMinWidth}
+        dayMaxEvents={options.dayMaxEvents}
+        dayMaxEventRows={options.dayMaxEventRows}
+        showWeekNumbers={options.weekNumbers}
+        expandRows={!props.isHeightAuto}
+        headerAlignElRef={this.headerElRef}
+        clientWidth={contentArg.clientWidth}
+        clientHeight={contentArg.clientHeight}
+        forPrint={props.forPrint}
+      />
+    )
+
+    return options.dayMinWidth
+      ? this.renderHScrollLayout(headerContent, bodyContent, dayTableModel.colCnt, options.dayMinWidth)
+      : this.renderSimpleLayout(headerContent, bodyContent)
+  }
+
+  // can't override any lifecycle methods from parent
+}
+
+export function buildDayTableModel(dateProfile: DateProfile, dateProfileGenerator: DateProfileGenerator) {
+  let daySeries = new DaySeriesModel(dateProfile.renderRange, dateProfileGenerator)
+
+  return new DayTableModel(
+    daySeries,
+    /year|month|week/.test(dateProfile.currentRangeUnit),
+  )
+}

--- a/packages/daygrid-overlaps/src/Table.tsx
+++ b/packages/daygrid-overlaps/src/Table.tsx
@@ -1,0 +1,135 @@
+import { CssDimValue } from '@fullcalendar/core'
+import { DateComponent, formatIsoMonthStr, formatDayString, DateProfile } from '@fullcalendar/core/internal'
+import { VNode, RefObject, createElement, createRef } from '@fullcalendar/core/preact'
+import { TableRows, TableRowsProps } from './TableRows.js'
+
+export interface TableProps extends TableRowsProps {
+  colGroupNode: VNode
+  tableMinWidth: CssDimValue
+  expandRows: boolean
+  headerAlignElRef?: RefObject<HTMLElement>
+}
+
+export class Table extends DateComponent<TableProps> {
+  private elRef = createRef<HTMLDivElement>()
+  private needsScrollReset = false
+
+  render() {
+    let { props } = this
+    let { dayMaxEventRows, dayMaxEvents, expandRows } = props
+    let limitViaBalanced = dayMaxEvents === true || dayMaxEventRows === true
+
+    // if rows can't expand to fill fixed height, can't do balanced-height event limit
+    // TODO: best place to normalize these options?
+    if (limitViaBalanced && !expandRows) {
+      limitViaBalanced = false
+      dayMaxEventRows = null
+      dayMaxEvents = null
+    }
+
+    let classNames = [
+      'fc-daygrid-body', // necessary for TableRows DnD parent
+      limitViaBalanced ? 'fc-daygrid-body-balanced' : 'fc-daygrid-body-unbalanced', // will all row heights be equal?
+      expandRows ? '' : 'fc-daygrid-body-natural', // will height of one row depend on the others?
+    ]
+
+    return (
+      <div
+        ref={this.elRef}
+        className={classNames.join(' ')}
+        style={{
+          // these props are important to give this wrapper correct dimensions for interactions
+          // TODO: if we set it here, can we avoid giving to inner tables?
+          width: props.clientWidth,
+          minWidth: props.tableMinWidth,
+        }}
+      >
+        <table
+          role="presentation"
+          className="fc-scrollgrid-sync-table"
+          style={{
+            width: props.clientWidth,
+            minWidth: props.tableMinWidth,
+            height: expandRows ? props.clientHeight : '',
+          }}
+        >
+          {props.colGroupNode}
+          <tbody role="presentation">
+            <TableRows
+              dateProfile={props.dateProfile}
+              cells={props.cells}
+              renderRowIntro={props.renderRowIntro}
+              showWeekNumbers={props.showWeekNumbers}
+              clientWidth={props.clientWidth}
+              clientHeight={props.clientHeight}
+              businessHourSegs={props.businessHourSegs}
+              bgEventSegs={props.bgEventSegs}
+              fgEventSegs={props.fgEventSegs}
+              dateSelectionSegs={props.dateSelectionSegs}
+              eventSelection={props.eventSelection}
+              eventDrag={props.eventDrag}
+              eventResize={props.eventResize}
+              dayMaxEvents={dayMaxEvents}
+              dayMaxEventRows={dayMaxEventRows}
+              forPrint={props.forPrint}
+              isHitComboAllowed={props.isHitComboAllowed}
+            />
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+
+  componentDidMount(): void {
+    this.requestScrollReset()
+  }
+
+  componentDidUpdate(prevProps: TableProps): void {
+    if (prevProps.dateProfile !== this.props.dateProfile) {
+      this.requestScrollReset()
+    } else {
+      this.flushScrollReset()
+    }
+  }
+
+  requestScrollReset() {
+    this.needsScrollReset = true
+    this.flushScrollReset()
+  }
+
+  flushScrollReset() {
+    if (
+      this.needsScrollReset &&
+      this.props.clientWidth // sizes computed?
+    ) {
+      const subjectEl = getScrollSubjectEl(this.elRef.current, this.props.dateProfile)
+
+      if (subjectEl) {
+        const originEl = subjectEl.closest('.fc-daygrid-body')
+        const scrollEl = originEl.closest('.fc-scroller')
+        const scrollTop = subjectEl.getBoundingClientRect().top -
+          originEl.getBoundingClientRect().top
+
+        scrollEl.scrollTop = scrollTop ? (scrollTop + 1) : 0 // overcome border
+      }
+
+      this.needsScrollReset = false
+    }
+  }
+}
+
+function getScrollSubjectEl(containerEl: HTMLElement, dateProfile: DateProfile): HTMLElement | undefined {
+  let el: HTMLElement
+
+  if (dateProfile.currentRangeUnit.match(/year|month/)) {
+    el = containerEl.querySelector(`[data-date="${formatIsoMonthStr(dateProfile.currentDate)}-01"]`)
+    // even if view is month-based, first-of-month might be hidden...
+  }
+
+  if (!el) {
+    el = containerEl.querySelector(`[data-date="${formatDayString(dateProfile.currentDate)}"]`)
+    // could still be hidden if an interior-view hidden day
+  }
+
+  return el
+}

--- a/packages/daygrid-overlaps/src/TableBlockEvent.tsx
+++ b/packages/daygrid-overlaps/src/TableBlockEvent.tsx
@@ -1,0 +1,23 @@
+import { StandardEvent, BaseComponent, MinimalEventProps } from '@fullcalendar/core/internal'
+import { createElement } from '@fullcalendar/core/preact'
+import { DEFAULT_TABLE_EVENT_TIME_FORMAT } from './event-rendering.js'
+
+export interface TableBlockEventProps extends MinimalEventProps {
+  defaultDisplayEventEnd: boolean
+}
+
+export class TableBlockEvent extends BaseComponent<TableBlockEventProps> {
+  render() {
+    let { props } = this
+
+    return (
+      <StandardEvent
+        {...props}
+        elClasses={['fc-daygrid-event', 'fc-daygrid-block-event', 'fc-h-event']}
+        defaultTimeFormat={DEFAULT_TABLE_EVENT_TIME_FORMAT}
+        defaultDisplayEventEnd={props.defaultDisplayEventEnd}
+        disableResizing={!props.seg.eventRange.def.allDay}
+      />
+    )
+  }
+}

--- a/packages/daygrid-overlaps/src/TableCell.tsx
+++ b/packages/daygrid-overlaps/src/TableCell.tsx
@@ -1,0 +1,185 @@
+import { CssDimValue, DayCellContentArg } from '@fullcalendar/core'
+import {
+  DateMarker,
+  DateComponent,
+  DateRange,
+  buildNavLinkAttrs,
+  WeekNumberContainer,
+  DayCellContainer,
+  DateProfile,
+  setRef,
+  createFormatter,
+  Dictionary,
+  EventSegUiInteractionState,
+  getUniqueDomId,
+  hasCustomDayCellContent,
+  addMs,
+  DateEnv,
+} from '@fullcalendar/core/internal'
+import {
+  Ref,
+  ComponentChildren,
+  createElement,
+  createRef,
+  ComponentChild,
+  Fragment,
+} from '@fullcalendar/core/preact'
+import { TableCellMoreLink } from './TableCellMoreLink.js'
+import { TableSegPlacement } from './event-placement.js'
+
+export interface TableCellProps {
+  elRef?: Ref<HTMLTableCellElement>
+  date: DateMarker
+  dateProfile: DateProfile
+  extraRenderProps?: Dictionary
+  extraDataAttrs?: Dictionary
+  extraClassNames?: string[]
+  extraDateSpan?: Dictionary
+  innerElRef?: Ref<HTMLDivElement>
+  bgContent: ComponentChildren
+  fgContentElRef?: Ref<HTMLDivElement> // TODO: rename!!! classname confusion. is the "event" div
+  fgContent: ComponentChildren
+  moreCnt: number
+  moreMarginTop: number
+  showDayNumber: boolean
+  showWeekNumber: boolean
+  forceDayTop: boolean
+  todayRange: DateRange
+  eventSelection: string
+  eventDrag: EventSegUiInteractionState | null
+  eventResize: EventSegUiInteractionState | null
+  singlePlacements: TableSegPlacement[]
+  minHeight?: CssDimValue
+}
+
+const DEFAULT_WEEK_NUM_FORMAT = createFormatter({ week: 'narrow' })
+
+export class TableCell extends DateComponent<TableCellProps> {
+  private rootElRef = createRef<HTMLElement>()
+  state = {
+    dayNumberId: getUniqueDomId(),
+  }
+
+  render() {
+    let { context, props, state, rootElRef } = this
+    let { options, dateEnv } = context
+    let { date, dateProfile } = props
+
+    // TODO: memoize this?
+    const isMonthStart = props.showDayNumber &&
+      shouldDisplayMonthStart(date, dateProfile.currentRange, dateEnv)
+
+    return (
+      <DayCellContainer
+        elTag="td"
+        elRef={this.handleRootEl}
+        elClasses={[
+          'fc-daygrid-day',
+          ...(props.extraClassNames || []),
+        ]}
+        elAttrs={{
+          ...props.extraDataAttrs,
+          ...(props.showDayNumber ? { 'aria-labelledby': state.dayNumberId } : {}),
+          role: 'gridcell',
+        }}
+        defaultGenerator={renderTopInner}
+        date={date}
+        dateProfile={dateProfile}
+        todayRange={props.todayRange}
+        showDayNumber={props.showDayNumber}
+        isMonthStart={isMonthStart}
+        extraRenderProps={props.extraRenderProps}
+      >
+        {(InnerContent, renderProps) => (
+          <div
+            ref={props.innerElRef}
+            className="fc-daygrid-day-frame fc-scrollgrid-sync-inner"
+            style={{ minHeight: props.minHeight }}
+          >
+            {props.showWeekNumber && (
+              <WeekNumberContainer
+                elTag="a"
+                elClasses={['fc-daygrid-week-number']}
+                elAttrs={buildNavLinkAttrs(context, date, 'week')}
+                date={date}
+                defaultFormat={DEFAULT_WEEK_NUM_FORMAT}
+              />
+            )}
+            {!renderProps.isDisabled &&
+              (props.showDayNumber || hasCustomDayCellContent(options) || props.forceDayTop) ? (
+                <div className="fc-daygrid-day-top">
+                  <InnerContent
+                    elTag="a"
+                    elClasses={[
+                      'fc-daygrid-day-number',
+                      isMonthStart && 'fc-daygrid-month-start',
+                    ]}
+                    elAttrs={{
+                      ...buildNavLinkAttrs(context, date),
+                      id: state.dayNumberId,
+                    }}
+                  />
+                </div>
+              ) : props.showDayNumber ? (
+                // for creating correct amount of space (see issue #7162)
+                <div className="fc-daygrid-day-top" style={{ visibility: 'hidden' }}>
+                  <a className="fc-daygrid-day-number">&nbsp;</a>
+                </div>
+              ) : undefined}
+            <div
+              className="fc-daygrid-day-events"
+              ref={props.fgContentElRef}
+            >
+              {props.fgContent}
+              <div className="fc-daygrid-day-bottom" style={{ marginTop: props.moreMarginTop }}>
+                <TableCellMoreLink
+                  allDayDate={date}
+                  singlePlacements={props.singlePlacements}
+                  moreCnt={props.moreCnt}
+                  alignmentElRef={rootElRef}
+                  alignGridTop={!props.showDayNumber}
+                  extraDateSpan={props.extraDateSpan}
+                  dateProfile={props.dateProfile}
+                  eventSelection={props.eventSelection}
+                  eventDrag={props.eventDrag}
+                  eventResize={props.eventResize}
+                  todayRange={props.todayRange}
+                />
+              </div>
+            </div>
+            <div className="fc-daygrid-day-bg">
+              {props.bgContent}
+            </div>
+          </div>
+        )}
+      </DayCellContainer>
+    )
+  }
+
+  handleRootEl = (el: HTMLElement) => {
+    setRef(this.rootElRef, el)
+    setRef(this.props.elRef, el)
+  }
+}
+
+function renderTopInner(props: DayCellContentArg): ComponentChild {
+  return props.dayNumberText || <Fragment>&nbsp;</Fragment>
+}
+
+function shouldDisplayMonthStart(date: DateMarker, currentRange: DateRange, dateEnv: DateEnv): boolean {
+  const { start: currentStart, end: currentEnd } = currentRange
+  const currentEndIncl = addMs(currentEnd, -1)
+  const currentFirstYear = dateEnv.getYear(currentStart)
+  const currentFirstMonth = dateEnv.getMonth(currentStart)
+  const currentLastYear = dateEnv.getYear(currentEndIncl)
+  const currentLastMonth = dateEnv.getMonth(currentEndIncl)
+
+  // spans more than one month?
+  return !(currentFirstYear === currentLastYear && currentFirstMonth === currentLastMonth) &&
+    Boolean(
+      // first date in current view?
+      date.valueOf() === currentStart.valueOf() ||
+      // a month-start that's within the current range?
+      (dateEnv.getDay(date) === 1 && date.valueOf() < currentEnd.valueOf()),
+    )
+}

--- a/packages/daygrid-overlaps/src/TableCellMoreLink.tsx
+++ b/packages/daygrid-overlaps/src/TableCellMoreLink.tsx
@@ -1,0 +1,115 @@
+import {
+  MoreLinkContainer,
+  BaseComponent,
+  memoize,
+  DateMarker,
+  Dictionary,
+  DateProfile,
+  DateRange,
+  EventSegUiInteractionState,
+  getSegMeta,
+} from '@fullcalendar/core/internal'
+import { createElement, RefObject, Fragment } from '@fullcalendar/core/preact'
+import { TableSegPlacement } from './event-placement.js'
+import { hasListItemDisplay } from './event-rendering.js'
+import { TableBlockEvent } from './TableBlockEvent.js'
+import { TableListItemEvent } from './TableListItemEvent.js'
+import { TableSeg } from './TableSeg.js'
+
+export interface TableCellMoreLinkProps {
+  allDayDate: DateMarker
+  singlePlacements: TableSegPlacement[]
+  moreCnt: number
+  alignmentElRef: RefObject<HTMLElement>
+  alignGridTop: boolean // for popover
+  extraDateSpan?: Dictionary
+  dateProfile: DateProfile
+  todayRange: DateRange
+  eventSelection: string
+  eventDrag: EventSegUiInteractionState | null
+  eventResize: EventSegUiInteractionState | null
+}
+
+export class TableCellMoreLink extends BaseComponent<TableCellMoreLinkProps> {
+  compileSegs = memoize(compileSegs)
+
+  render() {
+    let { props } = this
+    let { allSegs, invisibleSegs } = this.compileSegs(props.singlePlacements)
+
+    return (
+      <MoreLinkContainer
+        elClasses={['fc-daygrid-more-link']}
+        dateProfile={props.dateProfile}
+        todayRange={props.todayRange}
+        allDayDate={props.allDayDate}
+        moreCnt={props.moreCnt}
+        allSegs={allSegs}
+        hiddenSegs={invisibleSegs}
+        alignmentElRef={props.alignmentElRef}
+        alignGridTop={props.alignGridTop}
+        extraDateSpan={props.extraDateSpan}
+        popoverContent={() => {
+          let isForcedInvisible =
+            (props.eventDrag ? props.eventDrag.affectedInstances : null) ||
+            (props.eventResize ? props.eventResize.affectedInstances : null) ||
+            {}
+          return (
+            <Fragment>
+              {allSegs.map((seg) => {
+                let instanceId = seg.eventRange.instance.instanceId
+                return (
+                  <div
+                    className="fc-daygrid-event-harness"
+                    key={instanceId}
+                    style={{
+                      visibility: isForcedInvisible[instanceId] ? 'hidden' : ('' as any),
+                    }}
+                  >
+                    {hasListItemDisplay(seg) ? (
+                      <TableListItemEvent
+                        seg={seg}
+                        isDragging={false}
+                        isSelected={instanceId === props.eventSelection}
+                        defaultDisplayEventEnd={false}
+                        {...getSegMeta(seg, props.todayRange)}
+                      />
+                    ) : (
+                      <TableBlockEvent
+                        seg={seg}
+                        isDragging={false}
+                        isResizing={false}
+                        isDateSelecting={false}
+                        isSelected={instanceId === props.eventSelection}
+                        defaultDisplayEventEnd={false}
+                        {...getSegMeta(seg, props.todayRange)}
+                      />
+                    )}
+                  </div>
+                )
+              })}
+            </Fragment>
+          )
+        }}
+      />
+    )
+  }
+}
+
+function compileSegs(singlePlacements: TableSegPlacement[]): {
+  allSegs: TableSeg[]
+  invisibleSegs: TableSeg[]
+} {
+  let allSegs: TableSeg[] = []
+  let invisibleSegs: TableSeg[] = []
+
+  for (let placement of singlePlacements) {
+    allSegs.push(placement.seg)
+
+    if (!placement.isVisible) {
+      invisibleSegs.push(placement.seg)
+    }
+  }
+
+  return { allSegs, invisibleSegs }
+}

--- a/packages/daygrid-overlaps/src/TableDateProfileGenerator.ts
+++ b/packages/daygrid-overlaps/src/TableDateProfileGenerator.ts
@@ -1,0 +1,60 @@
+import {
+  DateProfileGenerator,
+  addWeeks, diffWeeks,
+  DateRange,
+  DateEnv,
+  addDays,
+} from '@fullcalendar/core/internal'
+
+export class TableDateProfileGenerator extends DateProfileGenerator {
+  // Computes the date range that will be rendered
+  buildRenderRange(currentRange, currentRangeUnit, isRangeAllDay): DateRange {
+    let renderRange = super.buildRenderRange(currentRange, currentRangeUnit, isRangeAllDay)
+    let { props } = this
+
+    return buildDayTableRenderRange({
+      currentRange: renderRange, // ???
+      snapToWeek: /^(year|month)$/.test(currentRangeUnit),
+      fixedWeekCount: props.fixedWeekCount,
+      dateEnv: props.dateEnv,
+    })
+  }
+}
+
+export function buildDayTableRenderRange(props: {
+  currentRange: DateRange,
+  snapToWeek: boolean,
+  fixedWeekCount: boolean,
+  dateEnv: DateEnv,
+}): DateRange {
+  let { dateEnv, currentRange } = props
+  let { start, end } = currentRange
+  let endOfWeek
+
+  // year and month views should be aligned with weeks. this is already done for week
+  if (props.snapToWeek) {
+    start = dateEnv.startOfWeek(start)
+
+    // make end-of-week if not already
+    endOfWeek = dateEnv.startOfWeek(end)
+    if (endOfWeek.valueOf() !== end.valueOf()) {
+      end = addWeeks(endOfWeek, 1)
+    }
+  }
+
+  // ensure 6 weeks
+  if (props.fixedWeekCount) {
+    // TODO: instead of these date-math gymnastics (for multimonth view),
+    // compute dateprofiles of all months, then use start of first and end of last.
+    let lastMonthRenderStart = dateEnv.startOfWeek(
+      dateEnv.startOfMonth(addDays(currentRange.end, -1)),
+    )
+
+    let rowCnt = Math.ceil( // could be partial weeks due to hiddenDays
+      diffWeeks(lastMonthRenderStart, end),
+    )
+    end = addWeeks(end, 6 - rowCnt)
+  }
+
+  return { start, end }
+}

--- a/packages/daygrid-overlaps/src/TableListItemEvent.tsx
+++ b/packages/daygrid-overlaps/src/TableListItemEvent.tsx
@@ -1,0 +1,67 @@
+import { EventContentArg } from '@fullcalendar/core'
+import {
+  BaseComponent,
+  Seg,
+  buildSegTimeText,
+  EventContainer,
+  getSegAnchorAttrs,
+} from '@fullcalendar/core/internal'
+import { createElement, Fragment } from '@fullcalendar/core/preact'
+import { DEFAULT_TABLE_EVENT_TIME_FORMAT } from './event-rendering.js'
+
+export interface DotTableEventProps {
+  seg: Seg
+  isDragging: boolean
+  isSelected: boolean
+  isPast: boolean
+  isFuture: boolean
+  isToday: boolean
+  defaultDisplayEventEnd: boolean
+  children?: never
+}
+
+export class TableListItemEvent extends BaseComponent<DotTableEventProps> {
+  render() {
+    let { props, context } = this
+    let { options } = context
+    let { seg } = props
+    let timeFormat = options.eventTimeFormat || DEFAULT_TABLE_EVENT_TIME_FORMAT
+    let timeText = buildSegTimeText(
+      seg,
+      timeFormat,
+      context,
+      true,
+      props.defaultDisplayEventEnd,
+    )
+
+    return (
+      <EventContainer
+        {...props}
+        elTag="a"
+        elClasses={['fc-daygrid-event', 'fc-daygrid-dot-event']}
+        elAttrs={getSegAnchorAttrs(props.seg, context)}
+        defaultGenerator={renderInnerContent}
+        timeText={timeText}
+        isResizing={false}
+        isDateSelecting={false}
+      />
+    )
+  }
+}
+
+function renderInnerContent(renderProps: EventContentArg) {
+  return (
+    <Fragment>
+      <div
+        className="fc-daygrid-event-dot"
+        style={{ borderColor: renderProps.borderColor || renderProps.backgroundColor }}
+      />
+      {renderProps.timeText && (
+        <div className="fc-event-time">{renderProps.timeText}</div>
+      )}
+      <div className="fc-event-title">
+        {renderProps.event.title || <Fragment>&nbsp;</Fragment>}
+      </div>
+    </Fragment>
+  )
+}

--- a/packages/daygrid-overlaps/src/TableRow.tsx
+++ b/packages/daygrid-overlaps/src/TableRow.tsx
@@ -1,0 +1,425 @@
+import { CssDimValue } from '@fullcalendar/core'
+import {
+	EventSegUiInteractionState,
+	DateComponent,
+	PositionCache,
+	RefMap,
+	DateRange,
+	getSegMeta,
+	DateProfile,
+	BgEvent,
+	renderFill,
+	isPropsEqual,
+	buildEventRangeKey,
+	sortEventSegs,
+	DayTableCell,
+} from '@fullcalendar/core/internal'
+import {
+	VNode,
+	createElement,
+	Fragment,
+	createRef,
+} from '@fullcalendar/core/preact'
+import { TableSeg, splitSegsByFirstCol } from './TableSeg.js'
+import { TableCell } from './TableCell.js'
+import { TableListItemEvent } from './TableListItemEvent.js'
+import { TableBlockEvent } from './TableBlockEvent.js'
+import { computeFgSegPlacement, generateSegKey, generateSegUid, TableSegPlacement } from './event-placement.js'
+import { hasListItemDisplay } from './event-rendering.js'
+
+// TODO: attach to window resize?
+
+export interface TableRowProps {
+	cells: DayTableCell[]
+	renderIntro?: () => VNode
+	businessHourSegs: TableSeg[]
+	bgEventSegs: TableSeg[]
+	fgEventSegs: TableSeg[]
+	dateSelectionSegs: TableSeg[]
+	eventSelection: string
+	eventDrag: EventSegUiInteractionState | null
+	eventResize: EventSegUiInteractionState | null
+	dayMaxEvents: boolean | number
+	dayMaxEventRows: boolean | number
+	clientWidth: number | null
+	clientHeight: number | null // simply for causing an updateSize, for when liquid height
+	dateProfile: DateProfile
+	todayRange: DateRange
+	showDayNumbers: boolean
+	showWeekNumbers: boolean
+	forPrint: boolean
+	cellMinHeight?: CssDimValue
+}
+
+interface TableRowState {
+	framePositions: PositionCache
+	maxContentHeight: number | null
+	segHeights: { [segUid: string]: number } // integers
+}
+
+export class TableRow extends DateComponent<TableRowProps, TableRowState> {
+	private cellElRefs = new RefMap<HTMLTableCellElement>() // the <td>
+	private frameElRefs = new RefMap<HTMLElement>() // the fc-daygrid-day-frame
+	private fgElRefs = new RefMap<HTMLDivElement>() // the fc-daygrid-day-events
+	private segHarnessRefs = new RefMap<HTMLDivElement>() // indexed by "instanceId:firstCol"
+	private rootElRef = createRef<HTMLTableRowElement>()
+
+	state: TableRowState = {
+		framePositions: null,
+		maxContentHeight: null,
+		segHeights: {},
+	}
+
+	render() {
+		let { props, state, context } = this
+		let { options } = context
+		let colCnt = props.cells.length
+
+		let businessHoursByCol = splitSegsByFirstCol(props.businessHourSegs, colCnt)
+		let bgEventSegsByCol = splitSegsByFirstCol(props.bgEventSegs, colCnt)
+		let highlightSegsByCol = splitSegsByFirstCol(this.getHighlightSegs(), colCnt)
+		let mirrorSegsByCol = splitSegsByFirstCol(this.getMirrorSegs(), colCnt)
+
+		let { singleColPlacements, multiColPlacements, moreCnts, moreMarginTops } = computeFgSegPlacement(
+			sortEventSegs(props.fgEventSegs, options.eventOrder) as TableSeg[],
+			props.dayMaxEvents,
+			props.dayMaxEventRows,
+			options.eventOrderStrict,
+			state.segHeights,
+			state.maxContentHeight,
+			props.cells,
+			options.eventOrder,
+		)
+
+		let isForcedInvisible = // TODO: messy way to compute this
+			(props.eventDrag && props.eventDrag.affectedInstances) ||
+			(props.eventResize && props.eventResize.affectedInstances) ||
+			{}
+
+		return (
+			<tr ref={this.rootElRef} role="row">
+				{props.renderIntro && props.renderIntro()}
+				{props.cells.map((cell, col) => {
+					let normalFgNodes = this.renderFgSegs(
+						col,
+						props.forPrint ? singleColPlacements[col] : multiColPlacements[col],
+						props.todayRange,
+						isForcedInvisible,
+					)
+
+					let mirrorFgNodes = this.renderFgSegs(
+						col,
+						buildMirrorPlacements(mirrorSegsByCol[col], multiColPlacements),
+						props.todayRange,
+						{},
+						Boolean(props.eventDrag),
+						Boolean(props.eventResize),
+						false, // date-selecting (because mirror is never drawn for date selection)
+					)
+
+					return (
+						<TableCell
+							key={cell.key}
+							elRef={this.cellElRefs.createRef(cell.key)}
+							innerElRef={this.frameElRefs.createRef(cell.key) /* FF <td> problem, but okay to use for left/right. TODO: rename prop */}
+							dateProfile={props.dateProfile}
+							date={cell.date}
+							showDayNumber={props.showDayNumbers}
+							showWeekNumber={props.showWeekNumbers && col === 0}
+							forceDayTop={props.showWeekNumbers /* even displaying weeknum for row, not necessarily day */}
+							todayRange={props.todayRange}
+							eventSelection={props.eventSelection}
+							eventDrag={props.eventDrag}
+							eventResize={props.eventResize}
+							extraRenderProps={cell.extraRenderProps}
+							extraDataAttrs={cell.extraDataAttrs}
+							extraClassNames={cell.extraClassNames}
+							extraDateSpan={cell.extraDateSpan}
+							moreCnt={moreCnts[col]}
+							moreMarginTop={moreMarginTops[col]}
+							singlePlacements={singleColPlacements[col]}
+							fgContentElRef={this.fgElRefs.createRef(cell.key)}
+							fgContent={( // Fragment scopes the keys
+								<Fragment>
+									<Fragment>{normalFgNodes}</Fragment>
+									<Fragment>{mirrorFgNodes}</Fragment>
+								</Fragment>
+							)}
+							bgContent={( // Fragment scopes the keys
+								<Fragment>
+									{this.renderFillSegs(highlightSegsByCol[col], 'highlight')}
+									{this.renderFillSegs(businessHoursByCol[col], 'non-business')}
+									{this.renderFillSegs(bgEventSegsByCol[col], 'bg-event')}
+								</Fragment>
+							)}
+							minHeight={props.cellMinHeight}
+						/>
+					)
+				})}
+			</tr>
+		)
+	}
+
+	componentDidMount() {
+		this.updateSizing(true)
+		this.context.addResizeHandler(this.handleResize)
+	}
+
+	componentDidUpdate(prevProps: TableRowProps, prevState: TableRowState) {
+		let currentProps = this.props
+
+		this.updateSizing(
+			!isPropsEqual(prevProps, currentProps),
+		)
+	}
+
+	componentWillUnmount() {
+		this.context.removeResizeHandler(this.handleResize)
+	}
+
+	handleResize = (isForced: boolean) => {
+		if (isForced) {
+			this.updateSizing(true) // isExternal=true
+		}
+	}
+
+	getHighlightSegs(): TableSeg[] {
+		let { props } = this
+
+		if (props.eventDrag && props.eventDrag.segs.length) { // messy check
+			return props.eventDrag.segs as TableSeg[]
+		}
+
+		if (props.eventResize && props.eventResize.segs.length) { // messy check
+			return props.eventResize.segs as TableSeg[]
+		}
+
+		return props.dateSelectionSegs
+	}
+
+	getMirrorSegs(): TableSeg[] {
+		let { props } = this
+
+		if (props.eventResize && props.eventResize.segs.length) { // messy check
+			return props.eventResize.segs as TableSeg[]
+		}
+
+		return []
+	}
+
+	renderFgSegs(
+		col: number,
+		segPlacements: TableSegPlacement[],
+		todayRange: DateRange,
+		isForcedInvisible: { [instanceId: string]: any },
+		isDragging?: boolean,
+		isResizing?: boolean,
+		isDateSelecting?: boolean,
+	): VNode[] {
+		let { context } = this
+		let { eventSelection } = this.props
+		let { framePositions } = this.state
+		let defaultDisplayEventEnd = this.props.cells.length === 1 // colCnt === 1
+		let isMirror = isDragging || isResizing || isDateSelecting
+		let nodes: VNode[] = []
+
+		if (framePositions) {
+			for (let placement of segPlacements) {
+				let { seg } = placement
+				let { instanceId } = seg.eventRange.instance
+				let isVisible = placement.isVisible && !isForcedInvisible[instanceId]
+				let isAbsolute = placement.isAbsolute
+				let left: CssDimValue = ''
+				let right: CssDimValue = ''
+
+				if (isAbsolute) {
+					if (context.isRtl) {
+						right = 0
+						left = framePositions.lefts[seg.lastCol] - framePositions.lefts[seg.firstCol]
+					} else {
+						left = 0
+						right = framePositions.rights[seg.firstCol] - framePositions.rights[seg.lastCol]
+					}
+				}
+
+				/*
+				known bug: events that are force to be list-item but span multiple days still take up space in later columns
+				todo: in print view, for multi-day events, don't display title within non-start/end segs
+				*/
+				nodes.push(
+					<div
+						className={'fc-daygrid-event-harness' + (isAbsolute ? ' fc-daygrid-event-harness-abs' : '')}
+						key={generateSegKey(seg)}
+						ref={isMirror ? null : this.segHarnessRefs.createRef(generateSegUid(seg))}
+						style={{
+							visibility: isVisible ? ('' as any) : 'hidden',
+							marginTop: isAbsolute ? '' : placement.marginTop,
+							top: isAbsolute ? placement.absoluteTop : '',
+							left,
+							right,
+						}}
+					>
+						{hasListItemDisplay(seg) ? (
+							<TableListItemEvent
+								seg={seg}
+								isDragging={isDragging}
+								isSelected={instanceId === eventSelection}
+								defaultDisplayEventEnd={defaultDisplayEventEnd}
+								{...getSegMeta(seg, todayRange)}
+							/>
+						) : (
+							<TableBlockEvent
+								seg={seg}
+								isDragging={isDragging}
+								isResizing={isResizing}
+								isDateSelecting={isDateSelecting}
+								isSelected={instanceId === eventSelection}
+								defaultDisplayEventEnd={defaultDisplayEventEnd}
+								{...getSegMeta(seg, todayRange)}
+							/>
+						)}
+					</div>,
+				)
+			}
+		}
+
+		return nodes
+	}
+
+	renderFillSegs(segs: TableSeg[], fillType: string): VNode {
+		let { isRtl } = this.context
+		let { todayRange } = this.props
+		let { framePositions } = this.state
+		let nodes: VNode[] = []
+
+		if (framePositions) {
+			for (let seg of segs) {
+				let leftRightCss = isRtl ? {
+					right: 0,
+					left: framePositions.lefts[seg.lastCol] - framePositions.lefts[seg.firstCol],
+				} : {
+					left: 0,
+					right: framePositions.rights[seg.firstCol] - framePositions.rights[seg.lastCol],
+				}
+
+				nodes.push(
+					<div
+						key={buildEventRangeKey(seg.eventRange)}
+						className="fc-daygrid-bg-harness"
+						style={leftRightCss}
+					>
+						{fillType === 'bg-event' ?
+							<BgEvent seg={seg} {...getSegMeta(seg, todayRange)} /> :
+							renderFill(fillType)}
+					</div>,
+				)
+			}
+		}
+
+		return createElement(Fragment, {}, ...nodes)
+	}
+
+	updateSizing(isExternalSizingChange) {
+		let { props, state, frameElRefs } = this
+
+		if (
+			!props.forPrint &&
+			props.clientWidth !== null // positioning ready?
+		) {
+			if (isExternalSizingChange) {
+				let frameEls = props.cells.map((cell) => frameElRefs.currentMap[cell.key])
+
+				if (frameEls.length) {
+					let originEl = this.rootElRef.current
+					let newPositionCache = new PositionCache(
+						originEl,
+						frameEls,
+						true, // isHorizontal
+						false,
+					)
+
+					if (!state.framePositions || !state.framePositions.similarTo(newPositionCache)) {
+						this.setState({ // will trigger isCellPositionsChanged...
+							framePositions: new PositionCache(
+								originEl,
+								frameEls,
+								true, // isHorizontal
+								false,
+							),
+						})
+					}
+				}
+			}
+
+			const oldSegHeights = this.state.segHeights
+			const newSegHeights = this.querySegHeights()
+			const limitByContentHeight = props.dayMaxEvents === true || props.dayMaxEventRows === true
+
+			this.safeSetState({
+				// HACK to prevent oscillations of events being shown/hidden from max-event-rows
+				// Essentially, once you compute an element's height, never null-out.
+				// TODO: always display all events, as visibility:hidden?
+				segHeights: { ...oldSegHeights, ...newSegHeights },
+
+				maxContentHeight: limitByContentHeight ? this.computeMaxContentHeight() : null,
+			})
+		}
+	}
+
+	querySegHeights() {
+		let segElMap = this.segHarnessRefs.currentMap
+		let segHeights: { [segUid: string]: number } = {}
+
+		// get the max height amongst instance segs
+		for (let segUid in segElMap) {
+			let height = Math.round(segElMap[segUid].getBoundingClientRect().height)
+			segHeights[segUid] = Math.max(segHeights[segUid] || 0, height)
+		}
+
+		return segHeights
+	}
+
+	computeMaxContentHeight() {
+		let firstKey = this.props.cells[0].key
+		let cellEl = this.cellElRefs.currentMap[firstKey]
+		let fcContainerEl = this.fgElRefs.currentMap[firstKey]
+
+		return cellEl.getBoundingClientRect().bottom - fcContainerEl.getBoundingClientRect().top
+	}
+
+	public getCellEls() {
+		let elMap = this.cellElRefs.currentMap
+
+		return this.props.cells.map((cell) => elMap[cell.key])
+	}
+}
+
+TableRow.addStateEquality({
+	segHeights: isPropsEqual,
+})
+
+function buildMirrorPlacements(mirrorSegs: TableSeg[], colPlacements: TableSegPlacement[][]): TableSegPlacement[] {
+	if (!mirrorSegs.length) {
+		return []
+	}
+	let topsByInstanceId = buildAbsoluteTopHash(colPlacements) // TODO: cache this at first render?
+	return mirrorSegs.map((seg: TableSeg) => ({
+		seg,
+		isVisible: true,
+		isAbsolute: true,
+		absoluteTop: topsByInstanceId[seg.eventRange.instance.instanceId],
+		marginTop: 0,
+	}))
+}
+
+function buildAbsoluteTopHash(colPlacements: TableSegPlacement[][]): { [instanceId: string]: number } {
+	let topsByInstanceId: { [instanceId: string]: number } = {}
+
+	for (let placements of colPlacements) {
+		for (let placement of placements) {
+			topsByInstanceId[placement.seg.eventRange.instance.instanceId] = placement.absoluteTop
+		}
+	}
+
+	return topsByInstanceId
+}

--- a/packages/daygrid-overlaps/src/TableRows.tsx
+++ b/packages/daygrid-overlaps/src/TableRows.tsx
@@ -1,0 +1,204 @@
+import {
+  EventSegUiInteractionState,
+  DateComponent,
+  PositionCache,
+  memoize,
+  addDays,
+  RefMap,
+  DateRange,
+  NowTimer,
+  DateMarker,
+  DateProfile,
+  Hit,
+  DayTableCell,
+} from '@fullcalendar/core/internal'
+import { VNode, createElement, Fragment } from '@fullcalendar/core/preact'
+import { TableSeg, splitSegsByRow, splitInteractionByRow } from './TableSeg.js'
+import { TableRow } from './TableRow.js'
+
+export interface TableRowsProps {
+  dateProfile: DateProfile
+  cells: DayTableCell[][] // cells-BY-ROW
+  renderRowIntro?: () => VNode
+  showWeekNumbers: boolean
+  clientWidth: number | null // of outer view container. weird, i know
+  clientHeight: number | null // of outer view container. weird, i know
+  businessHourSegs: TableSeg[]
+  bgEventSegs: TableSeg[]
+  fgEventSegs: TableSeg[]
+  dateSelectionSegs: TableSeg[]
+  eventSelection: string
+  eventDrag: EventSegUiInteractionState | null
+  eventResize: EventSegUiInteractionState | null
+  dayMaxEvents: boolean | number
+  dayMaxEventRows: boolean | number
+  forPrint: boolean
+  isHitComboAllowed?: (hit0: Hit, hit1: Hit) => boolean
+}
+
+export class TableRows extends DateComponent<TableRowsProps> {
+  private splitBusinessHourSegs = memoize(splitSegsByRow)
+  private splitBgEventSegs = memoize(splitAllDaySegsByRow)
+  private splitFgEventSegs = memoize(splitSegsByRow)
+  private splitDateSelectionSegs = memoize(splitSegsByRow)
+  private splitEventDrag = memoize(splitInteractionByRow)
+  private splitEventResize = memoize(splitInteractionByRow)
+  private rootEl: HTMLElement
+  private rowRefs = new RefMap<TableRow>()
+  private rowPositions: PositionCache
+  private colPositions: PositionCache
+
+  render() {
+    let { props, context } = this
+    let rowCnt = props.cells.length
+
+    let businessHourSegsByRow = this.splitBusinessHourSegs(props.businessHourSegs, rowCnt)
+    let bgEventSegsByRow = this.splitBgEventSegs(props.bgEventSegs, rowCnt)
+    let fgEventSegsByRow = this.splitFgEventSegs(props.fgEventSegs, rowCnt)
+    let dateSelectionSegsByRow = this.splitDateSelectionSegs(props.dateSelectionSegs, rowCnt)
+    let eventDragByRow = this.splitEventDrag(props.eventDrag, rowCnt)
+    let eventResizeByRow = this.splitEventResize(props.eventResize, rowCnt)
+
+    // for DayGrid view with many rows, force a min-height on cells so doesn't appear squished
+    // choose 7 because a month view will have max 6 rows
+    let cellMinHeight = (rowCnt >= 7 && props.clientWidth) ?
+      props.clientWidth / context.options.aspectRatio / 6 :
+      null
+
+    return (
+      <NowTimer unit="day">{(nowDate: DateMarker, todayRange: DateRange) => (
+        <Fragment>
+          {props.cells.map((cells, row) => (
+            <TableRow
+              ref={this.rowRefs.createRef(row)}
+              key={
+                cells.length
+                  ? cells[0].date.toISOString() /* best? or put key on cell? or use diff formatter? */
+                  : row // in case there are no cells (like when resource view is loading)
+              }
+              showDayNumbers={rowCnt > 1}
+              showWeekNumbers={props.showWeekNumbers}
+              todayRange={todayRange}
+              dateProfile={props.dateProfile}
+              cells={cells}
+              renderIntro={props.renderRowIntro}
+              businessHourSegs={businessHourSegsByRow[row]}
+              eventSelection={props.eventSelection}
+              bgEventSegs={bgEventSegsByRow[row]}
+              fgEventSegs={fgEventSegsByRow[row]}
+              dateSelectionSegs={dateSelectionSegsByRow[row]}
+              eventDrag={eventDragByRow[row]}
+              eventResize={eventResizeByRow[row]}
+              dayMaxEvents={props.dayMaxEvents}
+              dayMaxEventRows={props.dayMaxEventRows}
+              clientWidth={props.clientWidth}
+              clientHeight={props.clientHeight}
+              cellMinHeight={cellMinHeight}
+              forPrint={props.forPrint}
+            />
+          ))}
+        </Fragment>
+      )}</NowTimer>
+    )
+  }
+
+  componentDidMount(): void {
+    this.registerInteractiveComponent()
+  }
+
+  componentDidUpdate(): void {
+    // for if started with zero cells
+    this.registerInteractiveComponent()
+  }
+
+  registerInteractiveComponent() {
+    if (!this.rootEl) {
+      // HACK: need a daygrid wrapper parent to do positioning
+      // NOTE: a daygrid resource view w/o resources can have zero cells
+      const firstCellEl = this.rowRefs.currentMap[0].getCellEls()[0]
+      const rootEl = firstCellEl ? firstCellEl.closest('.fc-daygrid-body')! as HTMLElement : null
+
+      if (rootEl) {
+        this.rootEl = rootEl
+
+        this.context.registerInteractiveComponent(this, {
+          el: rootEl,
+          isHitComboAllowed: this.props.isHitComboAllowed,
+        })
+      }
+    }
+  }
+
+  componentWillUnmount(): void {
+    if (this.rootEl) {
+      this.context.unregisterInteractiveComponent(this)
+      this.rootEl = null
+    }
+  }
+
+  // Hit System
+  // ----------------------------------------------------------------------------------------------------
+
+  prepareHits() {
+    this.rowPositions = new PositionCache(
+      this.rootEl,
+      this.rowRefs.collect().map((rowObj) => rowObj.getCellEls()[0]), // first cell el in each row. TODO: not optimal
+      false,
+      true, // vertical
+    )
+
+    this.colPositions = new PositionCache(
+      this.rootEl,
+      this.rowRefs.currentMap[0].getCellEls(), // cell els in first row
+      true, // horizontal
+      false,
+    )
+  }
+
+  queryHit(positionLeft: number, positionTop: number): Hit {
+    let { colPositions, rowPositions } = this
+    let col = colPositions.leftToIndex(positionLeft)
+    let row = rowPositions.topToIndex(positionTop)
+
+    if (row != null && col != null) {
+      let cell = this.props.cells[row][col]
+
+      return {
+        dateProfile: this.props.dateProfile,
+        dateSpan: {
+          range: this.getCellRange(row, col),
+          allDay: true,
+          ...cell.extraDateSpan,
+        },
+        dayEl: this.getCellEl(row, col),
+        rect: {
+          left: colPositions.lefts[col],
+          right: colPositions.rights[col],
+          top: rowPositions.tops[row],
+          bottom: rowPositions.bottoms[row],
+        },
+        layer: 0,
+      }
+    }
+
+    return null
+  }
+
+  private getCellEl(row, col) {
+    return this.rowRefs.currentMap[row].getCellEls()[col] // TODO: not optimal
+  }
+
+  private getCellRange(row, col) {
+    let start = this.props.cells[row][col].date
+    let end = addDays(start, 1)
+    return { start, end }
+  }
+}
+
+function splitAllDaySegsByRow(segs: TableSeg[], rowCnt: number): TableSeg[][] {
+  return splitSegsByRow(segs.filter(isSegAllDay), rowCnt)
+}
+
+function isSegAllDay(seg: TableSeg) {
+  return seg.eventRange.def.allDay
+}

--- a/packages/daygrid-overlaps/src/TableSeg.ts
+++ b/packages/daygrid-overlaps/src/TableSeg.ts
@@ -1,0 +1,61 @@
+import { EventSegUiInteractionState, Seg } from '@fullcalendar/core/internal'
+
+// this is a DATA STRUCTURE, not a component
+
+export interface TableSeg extends Seg {
+  row: number
+  firstCol: number
+  lastCol: number
+}
+
+export function splitSegsByRow(segs: TableSeg[], rowCnt: number) {
+  let byRow: TableSeg[][] = []
+
+  for (let i = 0; i < rowCnt; i += 1) {
+    byRow[i] = []
+  }
+
+  for (let seg of segs) {
+    byRow[seg.row].push(seg)
+  }
+
+  return byRow
+}
+
+export function splitSegsByFirstCol(segs: TableSeg[], colCnt: number) {
+  let byCol: TableSeg[][] = []
+
+  for (let i = 0; i < colCnt; i += 1) {
+    byCol[i] = []
+  }
+
+  for (let seg of segs) {
+    byCol[seg.firstCol].push(seg)
+  }
+
+  return byCol
+}
+
+export function splitInteractionByRow(ui: EventSegUiInteractionState | null, rowCnt: number) {
+  let byRow: EventSegUiInteractionState[] = []
+
+  if (!ui) {
+    for (let i = 0; i < rowCnt; i += 1) {
+      byRow[i] = null
+    }
+  } else {
+    for (let i = 0; i < rowCnt; i += 1) {
+      byRow[i] = {
+        affectedInstances: ui.affectedInstances,
+        isEvent: ui.isEvent,
+        segs: [],
+      }
+    }
+
+    for (let seg of ui.segs) {
+      byRow[seg.row].segs.push(seg)
+    }
+  }
+
+  return byRow
+}

--- a/packages/daygrid-overlaps/src/TableView.tsx
+++ b/packages/daygrid-overlaps/src/TableView.tsx
@@ -1,0 +1,135 @@
+import {
+  SimpleScrollGrid,
+  SimpleScrollGridSection,
+  ChunkContentCallbackArgs,
+  ScrollGridSectionConfig,
+  ViewContainer,
+  DateComponent,
+  ViewProps,
+  renderScrollShim,
+  getStickyHeaderDates,
+  getStickyFooterScrollbar,
+  ChunkConfigRowContent,
+  Dictionary,
+} from '@fullcalendar/core/internal'
+import {
+  VNode,
+  createElement,
+  createRef,
+  RefObject,
+} from '@fullcalendar/core/preact'
+
+/* An abstract class for the daygrid views, as well as month view. Renders one or more rows of day cells.
+----------------------------------------------------------------------------------------------------------------------*/
+// It is a manager for a Table subcomponent, which does most of the heavy lifting.
+// It is responsible for managing width/height.
+
+export abstract class TableView<State=Dictionary> extends DateComponent<ViewProps, State> {
+  protected headerElRef: RefObject<HTMLTableCellElement> = createRef<HTMLTableCellElement>()
+
+  renderSimpleLayout(
+    headerRowContent: ChunkConfigRowContent,
+    bodyContent: (contentArg: ChunkContentCallbackArgs) => VNode,
+  ) {
+    let { props, context } = this
+    let sections: SimpleScrollGridSection[] = []
+    let stickyHeaderDates = getStickyHeaderDates(context.options)
+
+    if (headerRowContent) {
+      sections.push({
+        type: 'header',
+        key: 'header',
+        isSticky: stickyHeaderDates,
+        chunk: {
+          elRef: this.headerElRef,
+          tableClassName: 'fc-col-header',
+          rowContent: headerRowContent,
+        },
+      })
+    }
+
+    sections.push({
+      type: 'body',
+      key: 'body',
+      liquid: true,
+      chunk: { content: bodyContent },
+    })
+
+    return (
+      <ViewContainer elClasses={['fc-daygrid']} viewSpec={context.viewSpec}>
+        <SimpleScrollGrid
+          liquid={!props.isHeightAuto && !props.forPrint}
+          collapsibleWidth={props.forPrint}
+          cols={[] /* TODO: make optional? */}
+          sections={sections}
+        />
+      </ViewContainer>
+    )
+  }
+
+  renderHScrollLayout(
+    headerRowContent: ChunkConfigRowContent,
+    bodyContent: (contentArg: ChunkContentCallbackArgs) => VNode,
+    colCnt: number,
+    dayMinWidth: number,
+  ) {
+    let ScrollGrid = this.context.pluginHooks.scrollGridImpl
+
+    if (!ScrollGrid) {
+      throw new Error('No ScrollGrid implementation')
+    }
+
+    let { props, context } = this
+    let stickyHeaderDates = !props.forPrint && getStickyHeaderDates(context.options)
+    let stickyFooterScrollbar = !props.forPrint && getStickyFooterScrollbar(context.options)
+    let sections: ScrollGridSectionConfig[] = []
+
+    if (headerRowContent) {
+      sections.push({
+        type: 'header',
+        key: 'header',
+        isSticky: stickyHeaderDates,
+        chunks: [{
+          key: 'main',
+          elRef: this.headerElRef,
+          tableClassName: 'fc-col-header',
+          rowContent: headerRowContent,
+        }],
+      })
+    }
+
+    sections.push({
+      type: 'body',
+      key: 'body',
+      liquid: true,
+      chunks: [{
+        key: 'main',
+        content: bodyContent,
+      }],
+    })
+
+    if (stickyFooterScrollbar) {
+      sections.push({
+        type: 'footer',
+        key: 'footer',
+        isSticky: true,
+        chunks: [{
+          key: 'main',
+          content: renderScrollShim,
+        }],
+      })
+    }
+
+    return (
+      <ViewContainer elClasses={['fc-daygrid']} viewSpec={context.viewSpec}>
+        <ScrollGrid
+          liquid={!props.isHeightAuto && !props.forPrint}
+          forPrint={props.forPrint}
+          collapsibleWidth={props.forPrint}
+          colGroups={[{ cols: [{ span: colCnt, minWidth: dayMinWidth }] }]}
+          sections={sections}
+        />
+      </ViewContainer>
+    )
+  }
+}

--- a/packages/daygrid-overlaps/src/event-placement.ts
+++ b/packages/daygrid-overlaps/src/event-placement.ts
@@ -1,0 +1,393 @@
+import { EventRenderRange } from '@fullcalendar/core'
+import {
+  SegHierarchy,
+  SegRect,
+  SegEntry,
+  SegInsertion,
+  buildEntryKey,
+  intersectRanges,
+  addDays,
+  DayTableCell,
+  intersectSpans,
+  compareByFieldSpecs,
+  OrderSpec,
+} from '@fullcalendar/core/internal'
+import { TableSeg } from './TableSeg.js'
+
+export interface TableSegPlacement {
+  seg: TableSeg
+  isVisible: boolean
+  isAbsolute: boolean
+  absoluteTop: number // populated regardless of isAbsolute
+  marginTop: number
+}
+
+export function generateSegKey(seg: TableSeg): string {
+  return seg.eventRange.instance.instanceId + ':' + seg.firstCol
+}
+
+export function generateSegUid(seg: TableSeg): string {
+  return generateSegKey(seg) + ':' + seg.lastCol
+}
+
+export function computeFgSegPlacement(
+  segs: TableSeg[], // assumed already sorted
+  dayMaxEvents: boolean | number,
+  dayMaxEventRows: boolean | number,
+  strictOrder: boolean,
+  segHeights: { [segUid: string]: number },
+  maxContentHeight: number | null,
+  cells: DayTableCell[],
+  eventOrderSpecs?: OrderSpec<any>[], // optional: used to detect equality in ordering
+) {
+  // getEntryThickness will prefer an explicit `thickness` on the SegEntry if present.
+  // This allows later segments that are equal in ordering to be given thickness 0
+  // so they don't push other entries down (thus allowing overlap).
+  let hierarchy = new DayGridSegHierarchy((segEntry: SegEntry) => {
+    // if SegEntry supplied an explicit thickness, use it
+    if ((segEntry as any).thickness != null) {
+      return (segEntry as any).thickness
+    }
+
+    // TODO: more DRY with generateSegUid
+    let segUid = segs[segEntry.index].eventRange.instance.instanceId +
+      ':' + segEntry.span.start +
+      ':' + (segEntry.span.end - 1)
+
+    // if no thickness known, assume 1 (if 0, so small it always fits)
+    return segHeights[segUid] || 1
+  })
+  hierarchy.allowReslicing = true
+  hierarchy.strictOrder = strictOrder
+
+  if (dayMaxEvents === true || dayMaxEventRows === true) {
+    hierarchy.maxCoord = maxContentHeight
+    hierarchy.hiddenConsumes = true
+  } else if (typeof dayMaxEvents === 'number') {
+    hierarchy.maxStackCnt = dayMaxEvents
+  } else if (typeof dayMaxEventRows === 'number') {
+    hierarchy.maxStackCnt = dayMaxEventRows
+    hierarchy.hiddenConsumes = true
+  }
+
+  // create segInputs only for segs with known heights
+  let segInputs: SegEntry[] = []
+  let unknownHeightSegs: TableSeg[] = []
+  // build compare objects so we can detect equal-order neighbors
+  let compareObjs: any[] = []
+  if (eventOrderSpecs && eventOrderSpecs.length) {
+    for (let i = 0; i < segs.length; i += 1) {
+      let seg = segs[i]
+      let eventRange = seg.eventRange as any
+      let eventDef = eventRange.def as any
+      let range = eventRange.instance ? eventRange.instance.range : eventRange.range
+      let start = range.start ? range.start.valueOf() : 0
+      let end = range.end ? range.end.valueOf() : 0
+
+      compareObjs.push({
+        ...eventDef.extendedProps,
+        ...eventDef,
+        id: eventDef.publicId,
+        start,
+        end,
+        duration: end - start,
+        allDay: Number(eventDef.allDay),
+        _seg: seg,
+      })
+    }
+  }
+
+  for (let i = 0; i < segs.length; i += 1) {
+    let seg = segs[i]
+    let segUid = generateSegUid(seg)
+    let eventHeight = segHeights[segUid]
+
+    if (eventHeight != null) {
+      // if this seg has the same order as the previous seg, give it zero thickness
+      // so it does not push down others and can overlap with the previous one.
+      let thickness = eventHeight
+      if (i > 0 && compareObjs.length && eventOrderSpecs && compareByFieldSpecs(compareObjs[i - 1], compareObjs[i], eventOrderSpecs) === 0) {
+        thickness = 0
+      }
+
+      segInputs.push({
+        index: i,
+        thickness,
+        span: {
+          start: seg.firstCol,
+          end: seg.lastCol + 1,
+        },
+      })
+    } else {
+      unknownHeightSegs.push(seg)
+    }
+  }
+
+  let hiddenEntries = hierarchy.addSegs(segInputs)
+  let segRects = hierarchy.toRects()
+
+  // If we have a content height to map times into pixels, modify multi-column rects
+  // into per-column rect clones with levelCoord/thickness based on time-of-day.
+  let rectsToPlace: SegRect[] = []
+  const DAY_MS = 24 * 60 * 60 * 1000
+
+  if (maxContentHeight != null) {
+    for (let rect of segRects) {
+      const seg = segs[rect.index]
+      const origRange = (seg as any).eventRange.range
+
+      // expand multi-column rect into per-column rects so each day-slice can have
+      // its own top/height based on the event's start/end within that day.
+      for (let col = rect.span.start; col < rect.span.end; col += 1) {
+        const dayStart = cells[col].date
+        const dayEnd = addDays(dayStart, 1)
+        const slice = intersectRanges(origRange, { start: dayStart, end: dayEnd })
+
+        if (slice) {
+          const startOffset = slice.start.valueOf() - dayStart.valueOf()
+          const endOffset = slice.end.valueOf() - dayStart.valueOf()
+          const levelCoord = Math.round((startOffset / DAY_MS) * maxContentHeight)
+          const thickness = Math.max(1, Math.round(((endOffset - startOffset) / DAY_MS) * maxContentHeight))
+
+          rectsToPlace.push({
+            index: rect.index,
+            span: { start: col, end: col + 1 },
+            thickness,
+            levelCoord,
+          })
+        }
+      }
+    }
+  } else {
+    rectsToPlace = segRects.slice()
+  }
+
+  let { singleColPlacements, multiColPlacements, leftoverMargins } = placeRects(rectsToPlace, segs, cells)
+
+  let moreCnts: number[] = []
+  let moreMarginTops: number[] = []
+
+  // add segs with unknown heights
+  for (let seg of unknownHeightSegs) {
+    multiColPlacements[seg.firstCol].push({
+      seg,
+      isVisible: false,
+      isAbsolute: true,
+      absoluteTop: 0,
+      marginTop: 0,
+    })
+
+    for (let col = seg.firstCol; col <= seg.lastCol; col += 1) {
+      singleColPlacements[col].push({
+        seg: resliceSeg(seg, col, col + 1, cells),
+        isVisible: false,
+        isAbsolute: false,
+        absoluteTop: 0,
+        marginTop: 0,
+      })
+    }
+  }
+
+  // add the hidden entries
+  for (let col = 0; col < cells.length; col += 1) {
+    moreCnts.push(0)
+  }
+  for (let hiddenEntry of hiddenEntries) {
+    let seg = segs[hiddenEntry.index]
+    let hiddenSpan = hiddenEntry.span
+
+    multiColPlacements[hiddenSpan.start].push({
+      seg: resliceSeg(seg, hiddenSpan.start, hiddenSpan.end, cells),
+      isVisible: false,
+      isAbsolute: true,
+      absoluteTop: 0,
+      marginTop: 0,
+    })
+
+    for (let col = hiddenSpan.start; col < hiddenSpan.end; col += 1) {
+      moreCnts[col] += 1
+      singleColPlacements[col].push({
+        seg: resliceSeg(seg, col, col + 1, cells),
+        isVisible: false,
+        isAbsolute: false,
+        absoluteTop: 0,
+        marginTop: 0,
+      })
+    }
+  }
+
+  // deal with leftover margins
+  for (let col = 0; col < cells.length; col += 1) {
+    moreMarginTops.push(leftoverMargins[col])
+  }
+
+  return { singleColPlacements, multiColPlacements, moreCnts, moreMarginTops }
+}
+
+// rects ordered by top coord, then left
+function placeRects(allRects: SegRect[], segs: TableSeg[], cells: DayTableCell[]) {
+  let rectsByEachCol = groupRectsByEachCol(allRects, cells.length)
+  let singleColPlacements: TableSegPlacement[][] = []
+  let multiColPlacements: TableSegPlacement[][] = []
+  let leftoverMargins: number[] = []
+
+  for (let col = 0; col < cells.length; col += 1) {
+    let rects = rectsByEachCol[col]
+
+    // compute all static segs in singlePlacements
+    let singlePlacements: TableSegPlacement[] = []
+    let currentHeight = 0
+    let currentMarginTop = 0
+    for (let rect of rects) {
+      let seg = segs[rect.index]
+      singlePlacements.push({
+        seg: resliceSeg(seg, col, col + 1, cells),
+        isVisible: true,
+        isAbsolute: false,
+        absoluteTop: rect.levelCoord,
+        marginTop: rect.levelCoord - currentHeight,
+      })
+      currentHeight = rect.levelCoord + rect.thickness
+    }
+
+    // compute mixed static/absolute segs in multiPlacements
+    let multiPlacements: TableSegPlacement[] = []
+    currentHeight = 0
+    currentMarginTop = 0
+    for (let rect of rects) {
+      let seg = segs[rect.index]
+      let isAbsolute = rect.span.end - rect.span.start > 1 // multi-column?
+      let isFirstCol = rect.span.start === col
+
+      currentMarginTop += rect.levelCoord - currentHeight // amount of space since bottom of previous seg
+      currentHeight = rect.levelCoord + rect.thickness // height will now be bottom of current seg
+
+      if (isAbsolute) {
+        currentMarginTop += rect.thickness
+        if (isFirstCol) {
+          multiPlacements.push({
+            seg: resliceSeg(seg, rect.span.start, rect.span.end, cells),
+            isVisible: true,
+            isAbsolute: true,
+            absoluteTop: rect.levelCoord,
+            marginTop: 0,
+          })
+        }
+      } else if (isFirstCol) {
+        multiPlacements.push({
+          seg: resliceSeg(seg, rect.span.start, rect.span.end, cells),
+          isVisible: true,
+          isAbsolute: false,
+          absoluteTop: rect.levelCoord,
+          marginTop: currentMarginTop, // claim the margin
+        })
+        currentMarginTop = 0
+      }
+    }
+
+    singleColPlacements.push(singlePlacements)
+    multiColPlacements.push(multiPlacements)
+    leftoverMargins.push(currentMarginTop)
+  }
+
+  return { singleColPlacements, multiColPlacements, leftoverMargins }
+}
+
+function groupRectsByEachCol(rects: SegRect[], colCnt: number): SegRect[][] {
+  let rectsByEachCol: SegRect[][] = []
+
+  for (let col = 0; col < colCnt; col += 1) {
+    rectsByEachCol.push([])
+  }
+
+  for (let rect of rects) {
+    for (let col = rect.span.start; col < rect.span.end; col += 1) {
+      rectsByEachCol[col].push(rect)
+    }
+  }
+
+  return rectsByEachCol
+}
+
+function resliceSeg(seg: TableSeg, spanStart: number, spanEnd: number, cells: DayTableCell[]): TableSeg {
+  if (seg.firstCol === spanStart && seg.lastCol === spanEnd - 1) {
+    return seg
+  }
+
+  let eventRange = seg.eventRange
+  let origRange = eventRange.range
+  let slicedRange = intersectRanges(origRange, {
+    start: cells[spanStart].date,
+    end: addDays(cells[spanEnd - 1].date, 1),
+  })
+
+  return {
+    ...seg,
+    firstCol: spanStart,
+    lastCol: spanEnd - 1,
+    eventRange: {
+      def: eventRange.def,
+      ui: { ...eventRange.ui, durationEditable: false }, // hack to disable resizing
+      instance: eventRange.instance,
+      range: slicedRange,
+    } as EventRenderRange,
+    isStart: seg.isStart && slicedRange.start.valueOf() === origRange.start.valueOf(),
+    isEnd: seg.isEnd && slicedRange.end.valueOf() === origRange.end.valueOf(),
+  }
+}
+
+class DayGridSegHierarchy extends SegHierarchy {
+  // config
+  hiddenConsumes: boolean = false
+
+  // allows us to keep hidden entries in the hierarchy so they take up space
+  forceHidden: { [entryId: string]: true } = {}
+
+  addSegs(segInputs: SegEntry[]): SegEntry[] {
+    const hiddenSegs = super.addSegs(segInputs)
+    const { entriesByLevel } = this
+    const excludeHidden = (entry: SegEntry) => !this.forceHidden[buildEntryKey(entry)]
+
+    // remove the forced-hidden segs
+    for (let level = 0; level < entriesByLevel.length; level += 1) {
+      entriesByLevel[level] = entriesByLevel[level].filter(excludeHidden)
+    }
+
+    return hiddenSegs
+  }
+
+  handleInvalidInsertion(insertion: SegInsertion, entry: SegEntry, hiddenEntries: SegEntry[]) {
+    const { entriesByLevel, forceHidden } = this
+    const { touchingEntry, touchingLevel, touchingLateral } = insertion
+
+    // the entry that the new insertion is touching must be hidden
+    if (this.hiddenConsumes && touchingEntry) {
+      const touchingEntryId = buildEntryKey(touchingEntry)
+
+      if (!forceHidden[touchingEntryId]) {
+        if (this.allowReslicing) {
+          // split up the touchingEntry, reinsert it
+          const hiddenEntry = {
+            ...touchingEntry,
+            span: intersectSpans(touchingEntry.span, entry.span), // hit the `entry` barrier
+          }
+
+          // reinsert the area that turned into a "more" link (so no other entries try to
+          // occupy the space) but mark it forced-hidden
+          const hiddenEntryId = buildEntryKey(hiddenEntry)
+          forceHidden[hiddenEntryId] = true
+          entriesByLevel[touchingLevel][touchingLateral] = hiddenEntry
+
+          hiddenEntries.push(hiddenEntry)
+          this.splitEntry(touchingEntry, entry, hiddenEntries)
+        } else {
+          forceHidden[touchingEntryId] = true
+          hiddenEntries.push(touchingEntry)
+        }
+      }
+    }
+
+    // will try to reslice...
+    super.handleInvalidInsertion(insertion, entry, hiddenEntries)
+  }
+}

--- a/packages/daygrid-overlaps/src/event-rendering.ts
+++ b/packages/daygrid-overlaps/src/event-rendering.ts
@@ -1,0 +1,21 @@
+import { createFormatter, DateFormatter } from '@fullcalendar/core/internal'
+import { TableSeg } from './TableSeg.js'
+
+export const DEFAULT_TABLE_EVENT_TIME_FORMAT: DateFormatter = createFormatter({
+  hour: 'numeric',
+  minute: '2-digit',
+  omitZeroMinute: true,
+  meridiem: 'narrow',
+})
+
+export function hasListItemDisplay(seg: TableSeg) {
+  let { display } = seg.eventRange.ui
+
+  return display === 'list-item' || (
+    display === 'auto' &&
+    !seg.eventRange.def.allDay &&
+    seg.firstCol === seg.lastCol && // can't be multi-day
+    seg.isStart && // "
+    seg.isEnd // "
+  )
+}

--- a/packages/daygrid-overlaps/src/index.css
+++ b/packages/daygrid-overlaps/src/index.css
@@ -1,0 +1,6 @@
+
+@import '../../core/src/styles/mixins';
+@import './styles/vars';
+
+@import './styles/daygrid';
+@import './styles/daygrid-event';

--- a/packages/daygrid-overlaps/src/index.global.ts
+++ b/packages/daygrid-overlaps/src/index.global.ts
@@ -1,0 +1,8 @@
+import { globalPlugins } from '@fullcalendar/core'
+import plugin from './index.js'
+import * as Internal from './internal.js'
+
+globalPlugins.push(plugin)
+
+export { plugin as default, Internal }
+export * from './index.js'

--- a/packages/daygrid-overlaps/src/index.ts
+++ b/packages/daygrid-overlaps/src/index.ts
@@ -1,0 +1,32 @@
+import { createPlugin, PluginDef } from '@fullcalendar/core'
+import { DayTableView } from './DayTableView.js'
+import { TableDateProfileGenerator } from './TableDateProfileGenerator.js'
+import './index.css'
+
+export default createPlugin({
+  name: '<%= pkgName %>',
+  initialView: 'dayGridMonth',
+  views: {
+    dayGrid: {
+      component: DayTableView,
+      dateProfileGeneratorClass: TableDateProfileGenerator,
+    },
+    dayGridDay: {
+      type: 'dayGrid',
+      duration: { days: 1 },
+    },
+    dayGridWeek: {
+      type: 'dayGrid',
+      duration: { weeks: 1 },
+    },
+    dayGridMonth: {
+      type: 'dayGrid',
+      duration: { months: 1 },
+      fixedWeekCount: true,
+    },
+    dayGridYear: {
+      type: 'dayGrid',
+      duration: { years: 1 },
+    },
+  },
+}) as PluginDef

--- a/packages/daygrid-overlaps/src/internal.ts
+++ b/packages/daygrid-overlaps/src/internal.ts
@@ -1,0 +1,11 @@
+import './index.css'
+
+export { DayTable } from './DayTable.js'
+export { DayTableSlicer } from './DayTableSlicer.js'
+export { TableDateProfileGenerator, buildDayTableRenderRange } from './TableDateProfileGenerator.js'
+export { Table } from './Table.js'
+export { TableRows } from './TableRows.js'
+export { TableSeg } from './TableSeg.js'
+export { TableView } from './TableView.js'
+export { buildDayTableModel } from './DayTableView.js'
+export { DayTableView as DayGridView } from './DayTableView.js'

--- a/packages/daygrid-overlaps/src/styles/daygrid-event.css
+++ b/packages/daygrid-overlaps/src/styles/daygrid-event.css
@@ -1,0 +1,76 @@
+
+.fc-daygrid-event { // make root-level, because will be dragged-and-dropped outside of a component root
+  position: relative; // for z-indexes assigned later
+  white-space: nowrap;
+  border-radius: 3px; // dot event needs this to when selected
+  font-size: var(--fc-small-font-size);
+}
+
+// --- the rectangle ("block") style of event ---
+
+.fc-daygrid-block-event {
+
+  & .fc-event-time {
+    font-weight: bold;
+  }
+
+  & .fc-event-time,
+  & .fc-event-title {
+    padding: 1px;
+  }
+
+}
+
+// --- the dot style of event ---
+
+.fc-daygrid-dot-event {
+  display: flex;
+  align-items: center;
+  padding: 2px 0;
+
+  & .fc-event-title {
+    flex-grow: 1;
+    flex-shrink: 1;
+    min-width: 0; // important for allowing to shrink all the way
+    overflow: hidden;
+    font-weight: bold;
+  }
+
+  &:hover,
+  &.fc-event-mirror {
+    background: rgba(0, 0, 0, 0.1);
+  }
+
+  &.fc-event-selected:before {
+    // expand hit area
+    top: -10px;
+    bottom: -10px;
+  }
+
+}
+
+.fc-daygrid-event-dot { // the actual dot
+  margin: 0 4px;
+  box-sizing: content-box;
+  width: 0;
+  height: 0;
+  border: calc(var(--fc-daygrid-event-dot-width) / 2) solid var(--fc-event-border-color);
+  border-radius: calc(var(--fc-daygrid-event-dot-width) / 2);
+}
+
+
+// --- spacing between time and title ---
+
+$daygrid-event-inner-margin: 3px;
+
+.fc-direction-ltr {
+  & .fc-daygrid-event .fc-event-time {
+    margin-right: $daygrid-event-inner-margin;
+  }
+}
+
+.fc-direction-rtl {
+  & .fc-daygrid-event .fc-event-time {
+    margin-left: $daygrid-event-inner-margin;
+  }
+}

--- a/packages/daygrid-overlaps/src/styles/daygrid.css
+++ b/packages/daygrid-overlaps/src/styles/daygrid.css
@@ -1,0 +1,221 @@
+
+$daygrid-non-business-z: 1;
+$daygrid-bg-event-z: 2;
+$daygrid-highlight-z: 3;
+$daygrid-topbottom-z: 4;
+$daygrid-weeknum-z: 5;
+$daygrid-event-z: 6;
+$daygrid-event-mirror-z: 7;
+
+
+// help things clear margins of inner content
+.fc-daygrid-day-frame,
+.fc-daygrid-day-events,
+.fc-daygrid-event-harness { // for event top/bottom margins
+  &:before { @include clearfix; }
+  &:after { @include clearfix; }
+}
+
+
+.fc {
+
+  & .fc-daygrid-body { // a <div> that wraps the table
+    position: relative;
+    z-index: 1; // container inner z-index's because <tr>s can't do it
+  }
+
+  & .fc-daygrid-day {
+    &.fc-day-today {
+      background-color: var(--fc-today-bg-color);
+    }
+  }
+
+  & .fc-daygrid-day-frame {
+    position: relative;
+    min-height: 100%; // seems to work better than `height` because sets height after rows/cells naturally do it
+  }
+
+  // cell top
+
+  & .fc-daygrid-day-top {
+    display: flex;
+    flex-direction: row-reverse;
+  }
+
+  & .fc-day-other .fc-daygrid-day-top {
+    opacity: 0.3;
+  }
+
+  // day number (within cell top)
+
+  & .fc-daygrid-day-number {
+    position: relative;
+    z-index: $daygrid-topbottom-z;
+    padding: 4px;
+  }
+
+  & .fc-daygrid-month-start { // on .fc-daygrid-day-number
+    font-weight: bold;
+    font-size: 1.1em;
+  }
+
+  // event container
+
+  & .fc-daygrid-day-events {
+    margin-top: 1px; // needs to be margin, not padding, so that available cell height can be computed
+  }
+
+  // positioning for balanced vs natural
+
+  & .fc-daygrid-body-balanced {
+    & .fc-daygrid-day-events {
+      position: absolute;
+      left: 0;
+      right: 0;
+    }
+  }
+
+  & .fc-daygrid-body-unbalanced {
+    & .fc-daygrid-day-events {
+      position: relative; // for containing abs positioned event harnesses
+      min-height: 2em; // in addition to being a min-height during natural height, equalizes the heights a little bit
+    }
+  }
+
+  & .fc-daygrid-body-natural { // can coexist with -unbalanced
+    & .fc-daygrid-day-events {
+      margin-bottom: 1em;
+    }
+  }
+
+  // event harness
+
+  & .fc-daygrid-event-harness {
+    position: relative;
+  }
+
+  & .fc-daygrid-event-harness-abs {
+    position: absolute;
+    top: 0; // fallback coords for when cannot yet be computed
+    left: 0; //
+    right: 0; //
+  }
+
+  & .fc-daygrid-bg-harness {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+  }
+
+  // bg content
+
+  & .fc-daygrid-day-bg {
+    & .fc-non-business { z-index: $daygrid-non-business-z }
+    & .fc-bg-event { z-index: $daygrid-bg-event-z }
+    & .fc-highlight { z-index: $daygrid-highlight-z }
+  }
+
+  // events
+
+  & .fc-daygrid-event {
+    z-index: $daygrid-event-z;
+    margin-top: 1px;
+  }
+
+  & .fc-daygrid-event.fc-event-mirror {
+    z-index: $daygrid-event-mirror-z;
+  }
+
+  // cell bottom (within day-events)
+
+  & .fc-daygrid-day-bottom {
+    font-size: .85em;
+    margin: 0 2px;
+
+    // can't use flexbox well inside tables. for floating
+    &:before { @include clearfix; }
+    &:after { @include clearfix; }
+  }
+
+  & .fc-daygrid-more-link {
+    position: relative;
+    z-index: $daygrid-topbottom-z;
+    margin-top: 1px;
+    max-width: 100%;
+    border-radius: 3px;
+    padding: 2px;
+    overflow: hidden;
+    white-space: nowrap;
+    line-height: 1; // undo themes that have thick line-height
+    cursor: pointer;
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.1);
+    }
+  }
+
+  // week number (within frame)
+
+  & .fc-daygrid-week-number {
+    position: absolute;
+    z-index: $daygrid-weeknum-z;
+    top: 0;
+    padding: 2px;
+    min-width: 1.5em;
+    text-align: center;
+    background-color: var(--fc-neutral-bg-color);
+    color: var(--fc-neutral-text-color);
+  }
+
+  // popover
+
+  & .fc-more-popover .fc-popover-body {
+    min-width: 220px;
+    padding: 10px;
+  }
+
+}
+
+.fc-direction-ltr .fc-daygrid-event.fc-event-start,
+.fc-direction-rtl .fc-daygrid-event.fc-event-end {
+  margin-left: 2px;
+}
+
+.fc-direction-ltr .fc-daygrid-event.fc-event-end,
+.fc-direction-rtl .fc-daygrid-event.fc-event-start {
+  margin-right: 2px;
+}
+
+.fc-direction-ltr {
+
+  & .fc-daygrid-more-link {
+    float: left;
+  }
+
+  & .fc-daygrid-week-number {
+    left: 0;
+    border-radius: 0 0 3px 0;
+  }
+
+}
+
+.fc-direction-rtl {
+
+  & .fc-daygrid-more-link {
+    float: right;
+  }
+
+  & .fc-daygrid-week-number {
+    right: 0;
+    border-radius: 0 0 0 3px;
+  }
+
+}
+
+.fc-liquid-hack {
+
+  & .fc-daygrid-day-frame {
+    position: static; // will cause inner absolute stuff to expand to <td>
+  }
+
+}

--- a/packages/daygrid-overlaps/src/styles/vars.css
+++ b/packages/daygrid-overlaps/src/styles/vars.css
@@ -1,0 +1,4 @@
+
+:root {
+  --fc-daygrid-event-dot-width: 8px;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   jasmine-jquery@2.1.1:
-    hash: ii5vcd4rtfy5ngsgq7effin6p4
+    hash: 67897d46cf39c5f967a51ffdefb9218080e44eded878a866b057bd84e8703db7
     path: scripts/patches/jasmine-jquery@2.1.1.patch
 
 importers:
@@ -81,6 +81,16 @@ importers:
     publishDirectory: ./dist
 
   packages/daygrid:
+    devDependencies:
+      '@fullcalendar-scripts/standard':
+        specifier: '*'
+        version: link:../../scripts
+      '@fullcalendar/core':
+        specifier: ~6.1.19
+        version: link:../core/dist
+    publishDirectory: ./dist
+
+  packages/daygrid-overlaps:
     devDependencies:
       '@fullcalendar-scripts/standard':
         specifier: '*'
@@ -307,7 +317,7 @@ importers:
         version: 5.3.0
       chokidar:
         specifier: ^2.1.5
-        version: 2.1.8(supports-color@6.1.0)
+        version: 2.1.8
       cleye:
         specifier: ^1.2.1
         version: 1.3.2
@@ -334,7 +344,7 @@ importers:
         version: 4.7.8
       jasmine-jquery:
         specifier: ^2.1.1
-        version: 2.1.1(patch_hash=ii5vcd4rtfy5ngsgq7effin6p4)
+        version: 2.1.1(patch_hash=67897d46cf39c5f967a51ffdefb9218080e44eded878a866b057bd84e8703db7)
       jquery:
         specifier: ^3.4.0
         version: 3.7.1
@@ -407,6 +417,9 @@ importers:
       '@fullcalendar/daygrid':
         specifier: workspace:*
         version: link:../packages/daygrid/dist
+      '@fullcalendar/daygrid-overlaps':
+        specifier: workspace:*
+        version: link:../packages/daygrid-overlaps/dist
       '@fullcalendar/google-calendar':
         specifier: workspace:*
         version: link:../packages/google-calendar/dist
@@ -3132,17 +3145,9 @@ packages:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
 
-  supports-color@6.1.0:
-    resolution: {integrity: sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==}
-    engines: {node: '>=6'}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  supports-color@9.4.0:
-    resolution: {integrity: sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==}
-    engines: {node: '>=12'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -3479,7 +3484,7 @@ snapshots:
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.2
       convert-source-map: 2.0.0
-      debug: 4.4.1(supports-color@9.4.0)
+      debug: 4.4.1
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3556,7 +3561,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.2
       '@babel/types': 7.28.2
-      debug: 4.4.1(supports-color@9.4.0)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -3585,7 +3590,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1(supports-color@9.4.0)
+      debug: 4.4.1
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -3601,7 +3606,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.1(supports-color@9.4.0)
+      debug: 4.4.1
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3772,7 +3777,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -3789,7 +3794,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
       eslint: 8.57.1
     optionalDependencies:
       typescript: 4.9.5
@@ -3805,7 +3810,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      debug: 4.4.1(supports-color@9.4.0)
+      debug: 4.4.1
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
@@ -3819,7 +3824,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.1(supports-color@9.4.0)
+      debug: 4.4.1
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.2
@@ -3879,9 +3884,9 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  anymatch@2.0.0(supports-color@6.1.0):
+  anymatch@2.0.0:
     dependencies:
-      micromatch: 3.1.10(supports-color@6.1.0)
+      micromatch: 3.1.10
       normalize-path: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -4048,11 +4053,11 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@1.20.3(supports-color@6.1.0):
+  body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9(supports-color@6.1.0)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.0
@@ -4076,7 +4081,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  braces@2.3.2(supports-color@6.1.0):
+  braces@2.3.2:
     dependencies:
       arr-flatten: 1.1.0
       array-unique: 0.3.2
@@ -4084,7 +4089,7 @@ snapshots:
       fill-range: 4.0.0
       isobject: 3.0.1
       repeat-element: 1.1.4
-      snapdragon: 0.8.2(supports-color@6.1.0)
+      snapdragon: 0.8.2
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
@@ -4159,18 +4164,18 @@ snapshots:
 
   chalk@5.3.0: {}
 
-  chokidar@2.1.8(supports-color@6.1.0):
+  chokidar@2.1.8:
     dependencies:
-      anymatch: 2.0.0(supports-color@6.1.0)
+      anymatch: 2.0.0
       async-each: 1.0.6
-      braces: 2.3.2(supports-color@6.1.0)
+      braces: 2.3.2
       glob-parent: 3.1.0
       inherits: 2.0.4
       is-binary-path: 1.0.1
       is-glob: 4.0.3
       normalize-path: 3.0.0
       path-is-absolute: 1.0.1
-      readdirp: 2.2.1(supports-color@6.1.0)
+      readdirp: 2.2.1
       upath: 1.2.0
     optionalDependencies:
       fsevents: 1.2.13
@@ -4253,7 +4258,7 @@ snapshots:
 
   connect@3.7.0:
     dependencies:
-      debug: 2.6.9(supports-color@6.1.0)
+      debug: 2.6.9
       finalhandler: 1.1.2
       parseurl: 1.3.3
       utils-merge: 1.0.1
@@ -4381,23 +4386,17 @@ snapshots:
 
   date-format@4.0.14: {}
 
-  debug@2.6.9(supports-color@6.1.0):
+  debug@2.6.9:
     dependencies:
       ms: 2.0.0
-    optionalDependencies:
-      supports-color: 6.1.0
 
-  debug@4.3.7(supports-color@6.1.0):
+  debug@4.3.7:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 6.1.0
 
-  debug@4.4.1(supports-color@9.4.0):
+  debug@4.4.1:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 9.4.0
 
   decode-uri-component@0.2.2: {}
 
@@ -4503,7 +4502,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.5
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
       engine.io-parser: 5.2.3
       ws: 8.17.1
     transitivePeerDependencies:
@@ -4750,7 +4749,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -4808,14 +4807,14 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
-  expand-brackets@2.1.4(supports-color@6.1.0):
+  expand-brackets@2.1.4:
     dependencies:
-      debug: 2.6.9(supports-color@6.1.0)
+      debug: 2.6.9
       define-property: 0.2.5
       extend-shallow: 2.0.1
       posix-character-classes: 0.1.1
       regex-not: 1.0.2
-      snapdragon: 0.8.2(supports-color@6.1.0)
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -4831,15 +4830,15 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extglob@2.0.4(supports-color@6.1.0):
+  extglob@2.0.4:
     dependencies:
       array-unique: 0.3.2
       define-property: 1.0.0
-      expand-brackets: 2.1.4(supports-color@6.1.0)
+      expand-brackets: 2.1.4
       extend-shallow: 2.0.1
       fragment-cache: 0.2.1
       regex-not: 1.0.2
-      snapdragon: 0.8.2(supports-color@6.1.0)
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -4867,7 +4866,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/runtime': 7.26.0
       core-js: 3.39.0
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
       lodash.isequal: 4.5.0
@@ -4899,7 +4898,7 @@ snapshots:
 
   finalhandler@1.1.2:
     dependencies:
-      debug: 2.6.9(supports-color@6.1.0)
+      debug: 2.6.9
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
@@ -4922,9 +4921,7 @@ snapshots:
 
   flatted@3.3.2: {}
 
-  follow-redirects@1.15.9(debug@4.4.1):
-    optionalDependencies:
-      debug: 4.4.1(supports-color@9.4.0)
+  follow-redirects@1.15.9: {}
 
   for-each@0.3.3:
     dependencies:
@@ -5113,10 +5110,10 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
-  http-proxy@1.18.1(debug@4.4.1):
+  http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.9(debug@4.4.1)
+      follow-redirects: 1.15.9
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -5354,7 +5351,7 @@ snapshots:
 
   jasmine-core@3.8.0: {}
 
-  jasmine-jquery@2.1.1(patch_hash=ii5vcd4rtfy5ngsgq7effin6p4): {}
+  jasmine-jquery@2.1.1(patch_hash=67897d46cf39c5f967a51ffdefb9218080e44eded878a866b057bd84e8703db7): {}
 
   jquery-simulate@1.0.2: {}
 
@@ -5408,7 +5405,7 @@ snapshots:
   karma@6.4.4:
     dependencies:
       '@colors/colors': 1.5.0
-      body-parser: 1.20.3(supports-color@6.1.0)
+      body-parser: 1.20.3
       braces: 3.0.3
       chokidar: 3.6.0
       connect: 3.7.0
@@ -5416,7 +5413,7 @@ snapshots:
       dom-serialize: 2.2.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      http-proxy: 1.18.1(debug@4.4.1)
+      http-proxy: 1.18.1
       isbinaryfile: 4.0.10
       lodash: 4.17.21
       log4js: 6.9.1
@@ -5495,7 +5492,7 @@ snapshots:
   log4js@6.9.1:
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
       flatted: 3.3.2
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -5536,20 +5533,20 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  micromatch@3.1.10(supports-color@6.1.0):
+  micromatch@3.1.10:
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
-      braces: 2.3.2(supports-color@6.1.0)
+      braces: 2.3.2
       define-property: 2.0.2
       extend-shallow: 3.0.2
-      extglob: 2.0.4(supports-color@6.1.0)
+      extglob: 2.0.4
       fragment-cache: 0.2.1
       kind-of: 6.0.3
-      nanomatch: 1.2.13(supports-color@6.1.0)
+      nanomatch: 1.2.13
       object.pick: 1.3.0
       regex-not: 1.0.2
-      snapdragon: 0.8.2(supports-color@6.1.0)
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -5605,7 +5602,7 @@ snapshots:
 
   nanoid@3.3.8: {}
 
-  nanomatch@1.2.13(supports-color@6.1.0):
+  nanomatch@1.2.13:
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
@@ -5616,7 +5613,7 @@ snapshots:
       kind-of: 6.0.3
       object.pick: 1.3.0
       regex-not: 1.0.2
-      snapdragon: 0.8.2(supports-color@6.1.0)
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -6067,10 +6064,10 @@ snapshots:
     dependencies:
       minimatch: 5.1.6
 
-  readdirp@2.2.1(supports-color@6.1.0):
+  readdirp@2.2.1:
     dependencies:
       graceful-fs: 4.2.11
-      micromatch: 3.1.10(supports-color@6.1.0)
+      micromatch: 3.1.10
       readable-stream: 2.3.8
     transitivePeerDependencies:
       - supports-color
@@ -6275,10 +6272,10 @@ snapshots:
     dependencies:
       kind-of: 3.2.2
 
-  snapdragon@0.8.2(supports-color@6.1.0):
+  snapdragon@0.8.2:
     dependencies:
       base: 0.11.2
-      debug: 2.6.9(supports-color@6.1.0)
+      debug: 2.6.9
       define-property: 0.2.5
       extend-shallow: 2.0.1
       map-cache: 0.2.2
@@ -6290,7 +6287,7 @@ snapshots:
 
   socket.io-adapter@2.5.5:
     dependencies:
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
       ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
@@ -6300,7 +6297,7 @@ snapshots:
   socket.io-parser@4.2.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -6309,7 +6306,7 @@ snapshots:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.5
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.7
       engine.io: 6.6.2
       socket.io-adapter: 2.5.5
       socket.io-parser: 4.2.4
@@ -6364,7 +6361,7 @@ snapshots:
   streamroller@3.1.5:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.1(supports-color@9.4.0)
+      debug: 4.4.1
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -6442,17 +6439,9 @@ snapshots:
     dependencies:
       has-flag: 3.0.0
 
-  supports-color@6.1.0:
-    dependencies:
-      has-flag: 3.0.0
-    optional: true
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-
-  supports-color@9.4.0:
-    optional: true
 
   supports-preserve-symlinks-flag@1.0.0: {}
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,118 +1,119 @@
 {
-  "private": true,
-  "name": "@fullcalendar-tests/standard",
-  "version": "0.0.2",
-  "dependencies": {
-    "@fullcalendar/bootstrap": "workspace:*",
-    "@fullcalendar/core": "workspace:*",
-    "@fullcalendar/daygrid": "workspace:*",
-    "@fullcalendar/google-calendar": "workspace:*",
-    "@fullcalendar/icalendar": "workspace:*",
-    "@fullcalendar/interaction": "workspace:*",
-    "@fullcalendar/list": "workspace:*",
-    "@fullcalendar/luxon3": "workspace:*",
-    "@fullcalendar/moment": "workspace:*",
-    "@fullcalendar/moment-timezone": "workspace:*",
-    "@fullcalendar/multimonth": "workspace:*",
-    "@fullcalendar/rrule": "workspace:*",
-    "@fullcalendar/timegrid": "workspace:*",
-    "fullcalendar": "workspace:*",
-    "luxon": "^2.0.0",
-    "moment": "^2.29.1",
-    "moment-timezone": "^0.5.40",
-    "xhr-mock": "^2.5.1"
-  },
-  "devDependencies": {
-    "@fullcalendar-scripts/standard": "*",
-    "@types/jasmine": "^3.3.12",
-    "@types/jasmine-jquery": "^1.5.33",
-    "@types/jquery": "^3.3.29",
-    "fetch-mock": "^9.11.0",
-    "handlebars": "^4.7.7"
-  },
-  "scripts": {
-    "build": "standard-scripts pkg:build",
-    "test": "standard-scripts pkg:test",
-    "test:dev": "standard-scripts pkg:test --dev",
-    "clean": "standard-scripts pkg:clean",
-    "lint": "eslint ."
-  },
-  "type": "module",
-  "tsConfig": {
-    "extends": "@fullcalendar-scripts/standard/config/tsconfig.browser.json",
-    "compilerOptions": {
-      "types": [
-        "jasmine",
-        "jasmine-jquery",
-        "jquery"
-      ],
-      "rootDir": "./src",
-      "outDir": "./dist/.tsout"
-    },
-    "include": [
-      "./src/**/*"
-    ]
-  },
-  "buildConfig": {
-    "exports": {
-      ".": {
-        "iife": true,
-        "iifeGenerator": "./scripts/generate-index-iife.js"
-      }
-    },
-    "iifeGlobals": {
-      "*": ""
-    }
-  },
-  "karmaConfig": {
-    "suites": {
-      "default": {
-        "files": [
-          "./dist/index.global.js"
-        ]
-      },
-      "pkg:global:locale": {
-        "files": [
-          "./node_modules/@fullcalendar/core/index.global.js",
-          "./node_modules/@fullcalendar/core/locales/ar.global.js",
-          "./node_modules/@fullcalendar/daygrid/index.global.js",
-          "./src/global-locale.js"
-        ]
-      },
-      "pkg:global:locales-all": {
-        "files": [
-          "./node_modules/@fullcalendar/core/index.global.js",
-          "./node_modules/@fullcalendar/core/locales-all.global.js",
-          "./node_modules/@fullcalendar/daygrid/index.global.js",
-          "./src/global-locales-all.js"
-        ]
-      },
-      "bundle:global:locale": {
-        "files": [
-          "./node_modules/fullcalendar/index.global.js",
-          "./node_modules/@fullcalendar/core/locales/ar.global.js",
-          "./src/global-locale.js"
-        ]
-      },
-      "bundle:global:locales-all": {
-        "files": [
-          "./node_modules/fullcalendar/index.global.js",
-          "./node_modules/@fullcalendar/core/locales-all.global.js",
-          "./src/global-locales-all.js"
-        ]
-      }
-    }
-  },
-  "exports": {
-    "./package.json": "./package.json",
-    "./scripts/*": "./scripts/*.js",
-    "./lib/*": {
-      "types": "./dist/.tsout/lib/*.d.ts",
-      "default": "./dist/.tsout/lib/*.js"
-    },
-    ".": {
-      "types": "./dist/.tsout/index.d.ts",
-      "default": "./dist/index.js"
-    }
-  }
+	"private": true,
+	"name": "@fullcalendar-tests/standard",
+	"version": "0.0.2",
+	"dependencies": {
+		"@fullcalendar/bootstrap": "workspace:*",
+		"@fullcalendar/core": "workspace:*",
+		"@fullcalendar/daygrid": "workspace:*",
+		"@fullcalendar/daygrid-overlaps": "workspace:*",
+		"@fullcalendar/google-calendar": "workspace:*",
+		"@fullcalendar/icalendar": "workspace:*",
+		"@fullcalendar/interaction": "workspace:*",
+		"@fullcalendar/list": "workspace:*",
+		"@fullcalendar/luxon3": "workspace:*",
+		"@fullcalendar/moment": "workspace:*",
+		"@fullcalendar/moment-timezone": "workspace:*",
+		"@fullcalendar/multimonth": "workspace:*",
+		"@fullcalendar/rrule": "workspace:*",
+		"@fullcalendar/timegrid": "workspace:*",
+		"fullcalendar": "workspace:*",
+		"luxon": "^2.0.0",
+		"moment": "^2.29.1",
+		"moment-timezone": "^0.5.40",
+		"xhr-mock": "^2.5.1"
+	},
+	"devDependencies": {
+		"@fullcalendar-scripts/standard": "*",
+		"@types/jasmine": "^3.3.12",
+		"@types/jasmine-jquery": "^1.5.33",
+		"@types/jquery": "^3.3.29",
+		"fetch-mock": "^9.11.0",
+		"handlebars": "^4.7.7"
+	},
+	"scripts": {
+		"build": "standard-scripts pkg:build",
+		"test": "standard-scripts pkg:test",
+		"test:dev": "standard-scripts pkg:test --dev",
+		"clean": "standard-scripts pkg:clean",
+		"lint": "eslint ."
+	},
+	"type": "module",
+	"tsConfig": {
+		"extends": "@fullcalendar-scripts/standard/config/tsconfig.browser.json",
+		"compilerOptions": {
+			"types": [
+				"jasmine",
+				"jasmine-jquery",
+				"jquery"
+			],
+			"rootDir": "./src",
+			"outDir": "./dist/.tsout"
+		},
+		"include": [
+			"./src/**/*"
+		]
+	},
+	"buildConfig": {
+		"exports": {
+			".": {
+				"iife": true,
+				"iifeGenerator": "./scripts/generate-index-iife.js"
+			}
+		},
+		"iifeGlobals": {
+			"*": ""
+		}
+	},
+	"karmaConfig": {
+		"suites": {
+			"default": {
+				"files": [
+					"./dist/index.global.js"
+				]
+			},
+			"pkg:global:locale": {
+				"files": [
+					"./node_modules/@fullcalendar/core/index.global.js",
+					"./node_modules/@fullcalendar/core/locales/ar.global.js",
+					"./node_modules/@fullcalendar/daygrid/index.global.js",
+					"./src/global-locale.js"
+				]
+			},
+			"pkg:global:locales-all": {
+				"files": [
+					"./node_modules/@fullcalendar/core/index.global.js",
+					"./node_modules/@fullcalendar/core/locales-all.global.js",
+					"./node_modules/@fullcalendar/daygrid/index.global.js",
+					"./src/global-locales-all.js"
+				]
+			},
+			"bundle:global:locale": {
+				"files": [
+					"./node_modules/fullcalendar/index.global.js",
+					"./node_modules/@fullcalendar/core/locales/ar.global.js",
+					"./src/global-locale.js"
+				]
+			},
+			"bundle:global:locales-all": {
+				"files": [
+					"./node_modules/fullcalendar/index.global.js",
+					"./node_modules/@fullcalendar/core/locales-all.global.js",
+					"./src/global-locales-all.js"
+				]
+			}
+		}
+	},
+	"exports": {
+		"./package.json": "./package.json",
+		"./scripts/*": "./scripts/*.js",
+		"./lib/*": {
+			"types": "./dist/.tsout/lib/*.d.ts",
+			"default": "./dist/.tsout/lib/*.js"
+		},
+		".": {
+			"types": "./dist/.tsout/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	}
 }

--- a/tests/src/view-render/daygrid-overlaps-proportional.ts
+++ b/tests/src/view-render/daygrid-overlaps-proportional.ts
@@ -1,0 +1,55 @@
+import { DayGridViewWrapper } from '../lib/wrappers/DayGridViewWrapper.js'
+import dayGridOverlapsPlugin from '@fullcalendar/daygrid-overlaps'
+import '../lib/dom-misc.js'
+
+describe('daygrid-overlaps proportional multiday placement', () => {
+  it('does not treat a slice that ends at 10:00 as overlapping an event that starts at 12:00 on the same day', () => {
+    const calendar = initCalendar({
+      initialDate: '2023-06-01',
+      initialView: 'dayGridMonth',
+      plugins: [dayGridOverlapsPlugin],
+      // ensure we have a constrained content height to map times into pixels
+      dayMaxEventRows: true,
+      events: [
+        // multiday event starting previous day and ending 2023-06-02 10:00
+        {
+          title: 'Multi Event',
+          start: '2023-06-01T20:00:00',
+          end: '2023-06-02T10:00:00',
+        },
+        // single-day event starting 2023-06-02 12:00
+        {
+          title: 'Midday Event',
+          start: '2023-06-02T12:00:00',
+          end: '2023-06-02T13:00:00',
+        },
+      ],
+    })
+
+    const dayGrid = new DayGridViewWrapper(calendar).dayGrid
+
+    // find event elements for June 2 by testing intersection with the day cell
+    const dayEl = dayGrid.getDayEl('2023-06-02')
+    const dayRect = dayEl.getBoundingClientRect()
+    const allEventEls = dayGrid.getEventEls()
+    const eventEls = allEventEls.filter((el: HTMLElement) => {
+      const r = el.getBoundingClientRect()
+      return !(r.bottom <= dayRect.top || r.top >= dayRect.bottom || r.right <= dayRect.left || r.left >= dayRect.right)
+    })
+
+    // there should be at least two event elements in that day
+    expect(eventEls.length).toBeGreaterThanOrEqual(2)
+
+    // find their bounding rects and ensure they don't vertically overlap
+    const rects = Array.from(eventEls).map((el: Element) => el.getBoundingClientRect())
+
+    // sort by top
+    rects.sort((a, b) => a.top - b.top)
+
+    // the bottom of the earlier rect should be <= top of the later rect (allow 1px tolerance)
+    const earlier = rects[0]
+    const later = rects[1]
+
+    expect(earlier.bottom <= later.top + 1).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- forked the daygrid plugin into packages/daygrid-overlaps with its own package name and globals, keeping the existing API surface
- updated computeFgSegPlacement to let equal-ordered events overlap and to size multi-day slices proportionally when constrained by content height
- passed event order specs into TableRow and added an integration test showing a 10:00 end no longer conflicts with a noon start

## Testing
- pnpm -w build
