### PR TITLE
Improve Korean locale translation

### DIFF
--- a/packages/core/src/locales/ko.ts
+++ b/packages/core/src/locales/ko.ts
@@ -3,17 +3,17 @@ import { LocaleInput } from '../index.js'
 export default {
   code: 'ko',
   buttonText: {
-    prev: '이전달',
-    next: '다음달',
+    prev: '이전',
+    next: '다음',
     today: '오늘',
-    year: '년도',
+    year: '연도',
     month: '월',
     week: '주',
     day: '일',
-    list: '일정목록',
+    list: '일정',
   },
   weekText: '주',
   allDayText: '종일',
-  moreLinkText: '개',
+  moreLinkText: '개 더보기',
   noEventsText: '일정이 없습니다',
 } as LocaleInput


### PR DESCRIPTION
 - **prev/next**: `이전달/다음달 -> 이전/다음` | The old translations literally meant "previous/next month", which is wrong in week, day, and year views
- **year**: `년도 -> 년` | Consistent with other CJK locales, `년도` means "fiscal/academic year", `년` is the correct unit for calendar year  
- **list**: `일정목록 -> 일정` | Shorter, matches common Korean calendar UIs. zh-cn also uses just `日程` (schedule) for the list view. 
- **moreLinkText**: `개 -> 개 더보기` | 더보기 means "See more"