### PR TITLE
use NumberFormat for day cell numbers instead of DateTimeFormat

### DIFF
--- a/packages/core/src/common/DayCellContainer.tsx
+++ b/packages/core/src/common/DayCellContainer.tsx
@@ -2,7 +2,6 @@ import { ComponentChild, createElement } from '../preact.js'
 import { DateMarker } from '../datelib/marker.js'
 import { DateRange } from '../datelib/date-range.js'
 import { getDateMeta, DateMeta, getDayClassNames } from '../component/date-rendering.js'
-import { createFormatter } from '../datelib/formatting.js'
 import { DateFormatter } from '../datelib/DateFormatter.js'
 import { formatDayString } from '../datelib/formatting-utils.js'
 import { MountArg } from './render-hook.js'
@@ -34,8 +33,6 @@ export interface DayCellContainerProps extends Partial<ElProps> {
   defaultGenerator?: (renderProps: DayCellContentArg) => ComponentChild
   children?: InnerContainerFunc<DayCellContentArg>
 }
-
-const DAY_NUM_FORMAT = createFormatter({ day: 'numeric' })
 
 export class DayCellContainer extends BaseComponent<DayCellContainerProps> {
   refineRenderProps = memoizeObjArg(refineRenderProps)
@@ -105,7 +102,9 @@ function refineRenderProps(raw: DayCellRenderPropsInput): DayCellContentArg {
   let { date, dateEnv, dateProfile, isMonthStart } = raw
   let dayMeta = getDateMeta(date, raw.todayRange, null, dateProfile)
   let dayNumberText = raw.showDayNumber ? (
-    dateEnv.format(date, isMonthStart ? raw.monthStartFormat : DAY_NUM_FORMAT)
+    isMonthStart
+      ? dateEnv.format(date, raw.monthStartFormat)
+      : dateEnv.locale.simpleNumberFormat.format(dateEnv.getDay(date))
   ) : ''
 
   return {


### PR DESCRIPTION
Day cells use `Intl.DateTimeFormat({ day: 'numeric' })` which maps to CLDR skeleton `d` ([Date_Format_Patterns](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns)).

In some locales, this skeleton includes literal suffixes by design.

This is correct CLDR behavior, but calendar cells should show bare numbers.
Replaced with `Intl.NumberFormat` which gives bare numbers in the locale's
numeral system.

### Before / After

| locales | CLDR pattern | before | after |
|---------|-------------|--------|-------|
| ko | [`d일`](https://github.com/unicode-org/cldr/blob/main/common/main/ko.xml#L3124) | 14일 | 14 |
| ja | [`d日`](https://github.com/unicode-org/cldr/blob/main/common/main/ja.xml#L3156) | 14日 | 14 |
| zh | [`d日`](https://github.com/unicode-org/cldr/blob/main/common/main/zh.xml#L3552) | 14日 | 14 |
| bs | [`d.`](https://github.com/unicode-org/cldr/blob/main/common/main/bs.xml#L5284) | 14. | 14 |
| cs | [`d.`](https://github.com/unicode-org/cldr/blob/main/common/main/cs.xml#L4477) | 14. | 14 |
| da | [`d.`](https://github.com/unicode-org/cldr/blob/main/common/main/da.xml#L2157) | 14. | 14 |
| hr | [`d.`](https://github.com/unicode-org/cldr/blob/main/common/main/hr.xml#L2220) | 14. | 14 |
| nb/nn | [`d.`](https://github.com/unicode-org/cldr/blob/main/common/main/no.xml#L4945) | 14. | 14 |
| sk | [`d.`](https://github.com/unicode-org/cldr/blob/main/common/main/sk.xml#L2113) | 14. | 14 |
| sl | [`d.`](https://github.com/unicode-org/cldr/blob/main/common/main/sl.xml#L2258) | 14. | 14 |
| fa | `d` ([Solar Hijri](https://en.wikipedia.org/wiki/Solar_Hijri_calendar)) | ۲۴ | ۱۴ |

fa has no suffix in CLDR but `DateTimeFormat` converts to Solar Hijri calendar,
changing the day value itself. `NumberFormat` formats the actual day number.

## We need all native language speakers' reviews!

- [x] Korean (ko)
- [ ] Japanese (ja)
- [ ] Chinese Simplified (zh)
- [ ] Bosnian (bs)
- [ ] Czech (cs)
- [ ] Danish (da)
- [ ] Croatian (hr)
- [ ] Norwegian Bokmal (nb)
- [ ] Norwegian Nynorsk (nn)
- [ ] Slovak (sk)
- [ ] Slovenian (sl)
- [ ] Persian (fa)

