### PR TITLE
support function weekText for CJK week number format

### DIFF
--- a/packages/core/src/datelib/DateFormatter.ts
+++ b/packages/core/src/datelib/DateFormatter.ts
@@ -38,8 +38,8 @@ export interface DateFormattingContext {
   locale: Locale,
   calendarSystem: CalendarSystem
   computeWeekNumber: (d: DateMarker) => number
-  weekText: string
-  weekTextLong: string
+  weekText: string | ((num: number) => string)
+  weekTextLong: string | ((num: number) => string)
   cmdFormatter?: CmdFormatterFunc
   defaultSeparator: string
 }

--- a/packages/core/src/datelib/env.ts
+++ b/packages/core/src/datelib/env.ts
@@ -22,8 +22,8 @@ export interface DateEnvSettings {
   locale: Locale
   weekNumberCalculation?: WeekNumberCalculation
   firstDay?: number, // will override what the locale wants
-  weekText?: string,
-  weekTextLong?: string
+  weekText?: string | ((num: number) => string),
+  weekTextLong?: string | ((num: number) => string)
   cmdFormatter?: CmdFormatterFunc
   defaultSeparator?: string
 }
@@ -46,8 +46,8 @@ export class DateEnv {
   weekDow: number // which day begins the week
   weekDoy: number // which day must be within the year, for computing the first week number
   weekNumberFunc: any
-  weekText: string // DON'T LIKE how options are confused with local
-  weekTextLong: string
+  weekText: string | ((num: number) => string) // DON'T LIKE how options are confused with local
+  weekTextLong: string | ((num: number) => string)
   cmdFormatter?: CmdFormatterFunc
   defaultSeparator: string
 

--- a/packages/core/src/datelib/formatting-native.ts
+++ b/packages/core/src/datelib/formatting-native.ts
@@ -282,11 +282,21 @@ function injectTzoStr(s: string, tzoStr: string): string {
 
 function formatWeekNumber(
   num: number,
-  weekText: string,
-  weekTextLong: string,
+  weekText: string | ((num: number) => string),
+  weekTextLong: string | ((num: number) => string),
   locale: Locale,
   display?: 'numeric' | 'narrow' | 'short' | 'long',
 ): string {
+  let numStr = locale.simpleNumberFormat.format(num)
+  let text = display === 'long' ? weekTextLong : weekText
+
+  if (typeof text === 'function') {
+    if (display !== 'numeric' && display != null) {
+      return text(num)
+    }
+    return numStr
+  }
+
   let parts = []
 
   if (display === 'long') {
@@ -299,7 +309,7 @@ function formatWeekNumber(
     parts.push(' ')
   }
 
-  parts.push(locale.simpleNumberFormat.format(num))
+  parts.push(numStr)
 
   if (locale.options.direction === 'rtl') { // TODO: use control characters instead?
     parts.reverse()

--- a/packages/core/src/locales/ja.ts
+++ b/packages/core/src/locales/ja.ts
@@ -12,7 +12,7 @@ export default {
     day: '日',
     list: '予定リスト',
   },
-  weekText: '週',
+  weekText(n) { return '第' + n + '週' },
   allDayText: '終日',
   moreLinkText(n) {
     return '他 ' + n + ' 件'

--- a/packages/core/src/locales/ko.ts
+++ b/packages/core/src/locales/ko.ts
@@ -12,7 +12,7 @@ export default {
     day: '일',
     list: '일정목록',
   },
-  weekText: '주',
+  weekText(n) { return n + '주차' },
   allDayText: '종일',
   moreLinkText: '개',
   noEventsText: '일정이 없습니다',

--- a/packages/core/src/locales/zh-cn.ts
+++ b/packages/core/src/locales/zh-cn.ts
@@ -17,7 +17,7 @@ export default {
     day: '日',
     list: '日程',
   },
-  weekText: '周',
+  weekText(n) { return '第' + n + '周' },
   allDayText: '全天',
   moreLinkText(n) {
     return '另外 ' + n + ' 个'

--- a/packages/core/src/locales/zh-tw.ts
+++ b/packages/core/src/locales/zh-tw.ts
@@ -12,7 +12,7 @@ export default {
     day: '天',
     list: '活動列表',
   },
-  weekText: '週',
+  weekText(n) { return '第' + n + '週' },
   allDayText: '整天',
   moreLinkText: '顯示更多',
   noEventsText: '沒有任何活動',

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -135,8 +135,8 @@ export const BASE_OPTION_REFINERS = {
   eventResizableFromStart: Boolean,
   displayEventTime: Boolean,
   displayEventEnd: Boolean,
-  weekText: String, // the short version
-  weekTextLong: String, // falls back to weekText
+  weekText: identity as Identity<string | ((num: number) => string)>, // the short version
+  weekTextLong: identity as Identity<string | ((num: number) => string)>, // falls back to weekText
   progressiveEventRendering: Boolean,
   businessHours: identity as Identity<BusinessHoursInput>,
   initialDate: identity as Identity<DateInput>,


### PR DESCRIPTION
Related: #3353, #7018

`formatWeekNumber` always prepends the label before the number, producing wrong
results for CJK locales:

- Korean: 주 1 → should be 1주차
- Japanese: 週 1 → should be 第1週
- Chinese: 周 1 / 週 1 → should be 第1周 / 第1週

Allow `weekText` / `weekTextLong` to accept a function, consistent with
`moreLinkText`, `viewHint`, and `navLinkHint`.

```js
// before
weekText: '週'           // renders "週 1"

// after
weekText(n) { return '第' + n + '週' }  // renders "第1週"
```

Updated locales: ko, ja, zh-cn, zh-tw

### CLDR week number patterns

第 prefix follows CLDR `yw` / `MMMMW` dateFormatItem patterns:

| locale | yw pattern | CLDR source |
|--------|-----------|-------------|
| ko | `Y년 w번째 주` | [ko.xml#L3182](https://github.com/unicode-org/cldr/blob/main/common/main/ko.xml#L3182) |
| ja | `Y年第w週` | [ja.xml#L3212](https://github.com/unicode-org/cldr/blob/main/common/main/ja.xml#L3212) |
| zh | `Y年第w周` | [zh.xml#L3604](https://github.com/unicode-org/cldr/blob/main/common/main/zh.xml#L3604) |
| zh-Hant | `Y年的第w週` | [zh_Hant.xml#L5169](https://github.com/unicode-org/cldr/blob/main/common/main/zh_Hant.xml#L5169) |
