### PR TITLE
Improve Norwegian Nynorsk (nn) locale

### DIFF
--- a/packages/preact/src/locales/nn.ts
+++ b/packages/preact/src/locales/nn.ts
@@ -16,5 +16,13 @@ export default {
   listText: 'Agenda',
   allDayText: 'Heile\ndagen',
   moreLinkText: 'til',
-  noEventsText: 'Ingen hendelser å vise',
+  noEventsText: 'Ingen hendingar å vise',
+  prevHint: 'Førre $0',
+  nextHint: 'Neste $0',
+  todayHint: 'Noverande $0',
+  viewHint: '$0 vising',
+  navLinkHint: 'Gå til $0',
+  moreLinkHint(eventCnt: number) {
+    return `Vis ${eventCnt} fleire hending${eventCnt === 1 ? '' : 'ar'}`
+  },
 } as LocaleInput


### PR DESCRIPTION
The `nn` (Nynorsk) locale was missing the accessibility hint strings that `nb` already has. This adds them and fixes one Bokmål-leftover word:

- Added `prevHint`, `nextHint`, `todayHint`, `viewHint`, `navLinkHint`, `moreLinkHint` (in Nynorsk).
- `noEventsText`: "Ingen hendelser å vise" → "Ingen hendingar å vise" (Bokmål → Nynorsk).

Disclosure: prepared with AI assistance and reviewed by me as a native Norwegian speaker.